### PR TITLE
Task 4: Migrate Python DB layer to Postgres/Supabase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+KCTCS Student Success Prediction - Full-stack ML + web application predicting student outcomes for Kentucky Community and Technical College System (KCTCS). Uses 5 ML models to generate retention predictions, early warnings, time-to-credential estimates, credential type forecasts, and GPA predictions for ~20K students.
+
+## Tech Stack
+
+| Layer | Technologies |
+|-------|-------------|
+| ML Pipeline | Python 3.8+, XGBoost, scikit-learn, pandas |
+| Frontend | Next.js 16, React 19, TypeScript, Tailwind CSS |
+| Charts | Recharts |
+| UI Components | shadcn/ui (Radix UI) |
+| Database | MariaDB 10.11, MySQL2 driver |
+| AI Features | OpenAI (natural language query analysis) |
+| Infrastructure | Docker Compose, Vercel |
+
+## Key Directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `ai_model/` | Python ML pipeline - 5 models (XGBoost + Random Forest) |
+| `codebenders-dashboard/` | Next.js web application |
+| `codebenders-dashboard/app/` | App Router pages and API routes |
+| `codebenders-dashboard/components/` | React components (shadcn/ui based) |
+| `codebenders-dashboard/lib/` | Utilities: prompt-analyzer.ts, query-executor.ts |
+| `operations/` | Database utilities and configuration |
+| `data/` | CSV data files (~20K students, ~500K courses) |
+
+## Essential Commands
+
+### ML Pipeline
+```bash
+pip install -r requirements.txt           # Install Python dependencies
+cd ai_model && python complete_ml_pipeline.py   # Run full pipeline
+python -m operations.test_db_connection   # Test DB connection
+```
+
+### Dashboard
+```bash
+cd codebenders-dashboard
+npm install                               # Install dependencies
+npm run dev                               # Dev server (localhost:3000)
+npm run build                             # Production build
+npm run lint                              # Lint check
+```
+
+### Docker
+```bash
+docker-compose up -d                      # Start MariaDB + phpMyAdmin
+docker-compose down -v                    # Stop and remove volumes
+```
+
+## Database Schema
+
+Three main tables in `Kentucky_Community_and_Technical_College_System`:
+- `student_predictions` - Student-level predictions (~20K records)
+- `course_predictions` - Course-level predictions (~500K records)
+- `ml_model_performance` - Model metrics and training history
+
+## Key Entry Points
+
+| File | Purpose |
+|------|---------|
+| `ai_model/complete_ml_pipeline.py:1` | Main ML entry point |
+| `codebenders-dashboard/app/page.tsx:1` | Dashboard home page |
+| `codebenders-dashboard/app/query/page.tsx:1` | Query interface page |
+| `codebenders-dashboard/lib/prompt-analyzer.ts:30` | LLM-powered SQL generation |
+| `operations/db_config.py:8` | Database configuration |
+
+## Python Environment
+
+- **Always** use the project virtualenv at `venv/` when running Python commands.
+- Activate with `source venv/bin/activate` or use `venv/bin/python` directly.
+- Install dependencies into the venv, not globally.
+
+## Git Commit Rules
+
+- **Never** add `Co-Authored-By` lines to commit messages.
+
+## Additional Documentation
+
+Check these files for detailed information on specific topics:
+
+| Topic | File |
+|-------|------|
+| Architectural patterns | `.claude/docs/architectural_patterns.md` |
+| Project overview | `README.md` |
+| Quick start guide | `QUICKSTART.md` |
+| Data field descriptions | `DATA_DICTIONARY.md` |
+| ML model details | `ML_MODELS_GUIDE.md` |
+| Dashboard features | `codebenders-dashboard/DASHBOARD_README.md` |
+| Database utilities | `operations/README.md` |
+| Docker setup | `DOCKER_SETUP.md` |

--- a/operations/__init__.py
+++ b/operations/__init__.py
@@ -1,7 +1,7 @@
 """
 Operations Package
 ==================
-Database utilities and configuration for KCTCS ML Pipeline
+Database utilities and configuration for Bishop State ML Pipeline
 """
 
 from .db_config import DB_CONFIG, TABLES

--- a/operations/db_config.py
+++ b/operations/db_config.py
@@ -1,16 +1,27 @@
 """
-Database Configuration for MariaDB
-===================================
-Credentials for Kentucky Community and Technical College System database
+Database Configuration for PostgreSQL (Supabase)
+==================================================
+Credentials for Bishop State student success prediction database
 """
 
-# MariaDB Connection Settings
+import os
+
+# --- Legacy MariaDB Connection Settings (preserved for reference) ---
+# DB_CONFIG = {
+#     'host': 'devcolor00.czqeeakaypfi.us-west-2.rds.amazonaws.com',
+#     'user': 'admin',
+#     'password': 'devcolor2025',
+#     'database': 'Kentucky_Community_and_Technical_College_System',
+#     'port': 3306
+# }
+
+# PostgreSQL Connection Settings (local Supabase defaults)
 DB_CONFIG = {
-    'host': 'devcolor00.czqeeakaypfi.us-west-2.rds.amazonaws.com',
-    'user': 'admin',
-    'password': 'devcolor2025',
-    'database': 'Kentucky_Community_and_Technical_College_System',
-    'port': 3306
+    'host': os.environ.get('DB_HOST', '127.0.0.1'),
+    'user': os.environ.get('DB_USER', 'postgres'),
+    'password': os.environ.get('DB_PASSWORD', 'postgres'),
+    'database': os.environ.get('DB_NAME', 'postgres'),
+    'port': int(os.environ.get('DB_PORT', '54332'))
 }
 
 # Table names

--- a/operations/db_utils.py
+++ b/operations/db_utils.py
@@ -1,11 +1,12 @@
 """
-Database Utilities for MariaDB
-===============================
+Database Utilities for PostgreSQL
+==================================
 Helper functions for database operations
 """
 
 import pandas as pd
-import pymysql
+import psycopg2
+from psycopg2.extras import RealDictCursor
 from sqlalchemy import create_engine, text
 from .db_config import DB_CONFIG, TABLES
 import warnings
@@ -13,16 +14,15 @@ warnings.filterwarnings('ignore')
 
 
 def get_connection():
-    """Create a PyMySQL connection to MariaDB"""
+    """Create a psycopg2 connection to PostgreSQL"""
     try:
-        connection = pymysql.connect(
+        connection = psycopg2.connect(
             host=DB_CONFIG['host'],
             user=DB_CONFIG['user'],
             password=DB_CONFIG['password'],
-            database=DB_CONFIG['database'],
+            dbname=DB_CONFIG['database'],
             port=DB_CONFIG['port'],
-            charset='utf8mb4',
-            cursorclass=pymysql.cursors.DictCursor
+            cursor_factory=RealDictCursor
         )
         print(f"✓ Connected to database: {DB_CONFIG['database']}")
         return connection
@@ -35,7 +35,7 @@ def get_sqlalchemy_engine():
     """Create SQLAlchemy engine for pandas operations"""
     try:
         connection_string = (
-            f"mysql+pymysql://{DB_CONFIG['user']}:{DB_CONFIG['password']}"
+            f"postgresql+psycopg2://{DB_CONFIG['user']}:{DB_CONFIG['password']}"
             f"@{DB_CONFIG['host']}:{DB_CONFIG['port']}/{DB_CONFIG['database']}"
         )
         engine = create_engine(connection_string, pool_pre_ping=True)
@@ -48,8 +48,8 @@ def get_sqlalchemy_engine():
 
 def save_dataframe_to_db(df, table_name, if_exists='replace', chunksize=1000):
     """
-    Save pandas DataFrame to MariaDB table
-    
+    Save pandas DataFrame to PostgreSQL table
+
     Parameters:
     -----------
     df : pandas.DataFrame
@@ -63,26 +63,26 @@ def save_dataframe_to_db(df, table_name, if_exists='replace', chunksize=1000):
     """
     try:
         engine = get_sqlalchemy_engine()
-        
+
         print(f"\nSaving {len(df):,} records to table '{table_name}'...")
-        
+
         # Add upload timestamp
         from datetime import datetime
         df_to_save = df.copy()
         df_to_save['upload_timestamp'] = datetime.now()
-        
+
         # Save to database with progress tracking
         total_rows = len(df_to_save)
         rows_saved = 0
         status_interval = 10000
-        
+
         # Manual chunking to track progress
         for i in range(0, total_rows, chunksize):
             chunk = df_to_save.iloc[i:i+chunksize]
-            
+
             # Determine if_exists for this chunk
             chunk_if_exists = if_exists if i == 0 else 'append'
-            
+
             chunk.to_sql(
                 name=table_name,
                 con=engine,
@@ -91,27 +91,27 @@ def save_dataframe_to_db(df, table_name, if_exists='replace', chunksize=1000):
                 chunksize=None,  # Already chunked
                 method='multi'
             )
-            
+
             rows_saved += len(chunk)
-            
+
             # Show status every 10,000 records
             if rows_saved % status_interval == 0 or rows_saved == total_rows:
                 progress_pct = (rows_saved / total_rows) * 100
                 print(f"  Progress: {rows_saved:,} / {total_rows:,} records ({progress_pct:.1f}%)")
-        
+
         print(f"✓ Successfully saved to '{table_name}'")
         print(f"  - Records: {len(df):,}")
         print(f"  - Columns: {len(df.columns)}")
-        
+
         # Verify the save
         with engine.connect() as conn:
             result = conn.execute(text(f"SELECT COUNT(*) as count FROM {table_name}"))
             count = result.fetchone()[0]
             print(f"  - Verified: {count:,} records in database")
-        
+
         engine.dispose()
         return True
-        
+
     except Exception as e:
         print(f"✗ Failed to save to database: {e}")
         return False
@@ -122,10 +122,10 @@ def create_model_performance_table():
     try:
         connection = get_connection()
         cursor = connection.cursor()
-        
+
         create_table_sql = """
         CREATE TABLE IF NOT EXISTS ml_model_performance (
-            id INT AUTO_INCREMENT PRIMARY KEY,
+            id SERIAL PRIMARY KEY,
             model_name VARCHAR(100) NOT NULL,
             model_type VARCHAR(50) NOT NULL,
             accuracy FLOAT,
@@ -137,20 +137,29 @@ def create_model_performance_table():
             mae FLOAT,
             r2_score FLOAT,
             training_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            notes TEXT,
-            INDEX idx_model_name (model_name),
-            INDEX idx_training_date (training_date)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+            notes TEXT
+        );
         """
-        
+
         cursor.execute(create_table_sql)
+
+        # Create indexes separately for Postgres
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_model_name
+            ON ml_model_performance (model_name);
+        """)
+        cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_training_date
+            ON ml_model_performance (training_date);
+        """)
+
         connection.commit()
         print(f"✓ Model performance table created/verified")
-        
+
         cursor.close()
         connection.close()
         return True
-        
+
     except Exception as e:
         print(f"✗ Failed to create performance table: {e}")
         return False
@@ -159,7 +168,7 @@ def create_model_performance_table():
 def save_model_performance(model_name, model_type, metrics, notes=""):
     """
     Save model performance metrics to database
-    
+
     Parameters:
     -----------
     model_name : str
@@ -174,14 +183,14 @@ def save_model_performance(model_name, model_type, metrics, notes=""):
     try:
         connection = get_connection()
         cursor = connection.cursor()
-        
+
         insert_sql = """
-        INSERT INTO ml_model_performance 
-        (model_name, model_type, accuracy, precision_score, recall_score, 
+        INSERT INTO ml_model_performance
+        (model_name, model_type, accuracy, precision_score, recall_score,
          f1_score, auc_roc, rmse, mae, r2_score, notes)
         VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """
-        
+
         values = (
             model_name,
             model_type,
@@ -195,16 +204,16 @@ def save_model_performance(model_name, model_type, metrics, notes=""):
             metrics.get('r2_score'),
             notes
         )
-        
+
         cursor.execute(insert_sql, values)
         connection.commit()
-        
+
         print(f"✓ Saved performance metrics for '{model_name}'")
-        
+
         cursor.close()
         connection.close()
         return True
-        
+
     except Exception as e:
         print(f"✗ Failed to save model performance: {e}")
         return False
@@ -215,21 +224,23 @@ def test_connection():
     try:
         connection = get_connection()
         cursor = connection.cursor()
-        
-        cursor.execute("SELECT VERSION()")
+
+        cursor.execute("SELECT version()")
         version = cursor.fetchone()
-        print(f"✓ MariaDB version: {version}")
-        
-        cursor.execute("SHOW TABLES")
+        print(f"✓ PostgreSQL version: {version}")
+
+        cursor.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema='public'"
+        )
         tables = cursor.fetchall()
         print(f"✓ Existing tables: {len(tables)}")
         for table in tables:
-            print(f"  - {list(table.values())[0]}")
-        
+            print(f"  - {table['table_name']}")
+
         cursor.close()
         connection.close()
         return True
-        
+
     except Exception as e:
         print(f"✗ Connection test failed: {e}")
         return False

--- a/operations/test_db_connection.py
+++ b/operations/test_db_connection.py
@@ -1,14 +1,14 @@
 """
 Test Database Connection
 =========================
-Simple script to test MariaDB connection and verify credentials
+Simple script to test PostgreSQL connection and verify credentials
 """
 
 from .db_utils import test_connection, create_model_performance_table
 from .db_config import DB_CONFIG
 
 print("=" * 80)
-print("TESTING MARIADB CONNECTION")
+print("TESTING POSTGRES CONNECTION")
 print("=" * 80)
 print(f"\nDatabase: {DB_CONFIG['database']}")
 print(f"Host: {DB_CONFIG['host']}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pydantic>=2.0.0
 pandas>=2.0.0
 
 # Database
-pymysql>=1.0.0
+psycopg2-binary>=2.9.0
 sqlalchemy>=2.0.0
 cryptography>=41.0.0
 


### PR DESCRIPTION
## Summary
- Replace `pymysql` with `psycopg2` in `operations/db_utils.py`
- Update `operations/db_config.py` to env-var-driven config with local Supabase defaults (port 54332)
- Update SQLAlchemy connection string from `mysql+pymysql://` to `postgresql+psycopg2://`
- Update DDL for Postgres (`SERIAL`, separate `CREATE INDEX`, remove `ENGINE=InnoDB`)
- Update `test_connection()` to use Postgres system catalog queries
- Swap `pymysql` for `psycopg2-binary` in `requirements.txt`
- Add Python venv instructions to `CLAUDE.md`

## Test plan
- [x] `python -m operations.test_db_connection` passes against local Supabase (PostgreSQL 17.6)
- [x] `ml_model_performance` table created successfully
- [ ] Full ML pipeline run (Task 5) will validate end-to-end

Closes #35