### PR TITLE
Task 6: Create shared Postgres pool for Next.js, swap mysql2 for pg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ lerna-debug.log*
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+
+# Exceptions: dashboard source files that conflict with Python ignores above
+!codebenders-dashboard/lib/
+!codebenders-dashboard/lib/**
 dist/
 dist-ssr/
 *.local

--- a/codebenders-dashboard/lib/db.ts
+++ b/codebenders-dashboard/lib/db.ts
@@ -1,0 +1,23 @@
+import { Pool } from "pg"
+
+let pool: Pool | null = null
+
+export function getPool(): Pool {
+  if (!pool) {
+    if (!process.env.DB_HOST || !process.env.DB_USER || !process.env.DB_PASSWORD) {
+      throw new Error(
+        "Missing required database environment variables: DB_HOST, DB_USER, DB_PASSWORD"
+      )
+    }
+    pool = new Pool({
+      host: process.env.DB_HOST,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      port: Number.parseInt(process.env.DB_PORT || "6543"),
+      database: process.env.DB_NAME || "postgres",
+      ssl: process.env.DB_SSL === "true" ? { rejectUnauthorized: false } : false,
+      max: 10,
+    })
+  }
+  return pool
+}

--- a/codebenders-dashboard/lib/prompt-analyzer.ts
+++ b/codebenders-dashboard/lib/prompt-analyzer.ts
@@ -1,0 +1,174 @@
+import type { QueryPlan } from "./types"
+
+// Database schema mapping
+const SCHEMA_CONFIG = {
+  // Map institution codes to database names
+  institutionDbMap: {
+    kctcs: "Kentucky_Community_and_Technical_College_System",
+    akron: "University_of_Akron",
+  },
+  // Primary table for student-level analytics
+  mainTable: "cohort",
+  // Map metric names to actual column names
+  metricColumnMap: {
+    retention_rate: "Retention",
+    completion_rate: "Persistence",
+    gpa: "GPA_Group_Year_1",
+    credits_earned: "Number_of_Credits_Earned_Year_1",
+    count: "COUNT(*)",
+  },
+  // Map groupBy fields to actual column names
+  groupByColumnMap: {
+    cohort: "Cohort",
+    term: "Cohort_Term",
+    program: "Program_of_Study_Year_1",
+    course_code: "Course_Prefix",
+    enrollment_status: "Enrollment_Type",
+  },
+}
+
+export function analyzePrompt(prompt: string, institutionCode: string): QueryPlan {
+  const lowerPrompt = prompt.toLowerCase()
+
+  let metric: string | undefined
+  if (lowerPrompt.includes("retention")) {
+    metric = "retention_rate"
+  } else if (lowerPrompt.includes("completion") || lowerPrompt.includes("persistence")) {
+    metric = "completion_rate"
+  } else if (lowerPrompt.includes("gpa")) {
+    metric = "gpa"
+  } else if (lowerPrompt.includes("credit")) {
+    metric = "credits_earned"
+  } else if (lowerPrompt.includes("enrollment") || lowerPrompt.includes("count")) {
+    metric = "count"
+  }
+
+  let groupBy: string | undefined
+  if (lowerPrompt.includes("by cohort") || lowerPrompt.includes("cohort")) {
+    groupBy = "cohort"
+  } else if (lowerPrompt.includes("by term") || lowerPrompt.includes("term")) {
+    groupBy = "term"
+  } else if (lowerPrompt.includes("by program") || lowerPrompt.includes("program")) {
+    groupBy = "program"
+  } else if (lowerPrompt.includes("by course") || lowerPrompt.includes("course")) {
+    groupBy = "course_code"
+  } else if (lowerPrompt.includes("by status") || lowerPrompt.includes("status")) {
+    groupBy = "enrollment_status"
+  }
+
+  // Determine filters
+  const filters: Record<string, any> = {}
+
+  if (lowerPrompt.includes("last two terms") || lowerPrompt.includes("last 2 terms")) {
+    if (groupBy === "cohort") {
+      filters.cohort = ["2024-Fall", "2025-Spring"]
+    } else {
+      filters.term = ["Fall 2024", "Spring 2025"]
+    }
+  } else if (lowerPrompt.includes("2024")) {
+    filters.term = ["Spring 2024", "Fall 2024"]
+  } else if (lowerPrompt.includes("2025")) {
+    filters.term = ["Spring 2025", "Fall 2025"]
+  }
+
+  // Status filters
+  if (lowerPrompt.includes("enrolled")) {
+    filters.enrollment_status = "enrolled"
+  } else if (lowerPrompt.includes("completed")) {
+    filters.enrollment_status = "completed"
+  }
+
+  // Time hint
+  let timeHint: string | undefined
+  if (lowerPrompt.includes("last two terms") || lowerPrompt.includes("last 2 terms")) {
+    timeHint = "Last two terms"
+  } else if (lowerPrompt.includes("current")) {
+    timeHint = "Current term"
+  }
+
+  let vizType: QueryPlan["vizType"] = "bar"
+
+  if (groupBy === "term" || groupBy === "cohort") {
+    vizType = "line"
+  } else if (lowerPrompt.includes("share") || lowerPrompt.includes("percentage") || lowerPrompt.includes("breakdown")) {
+    vizType = "pie"
+  } else if (!groupBy) {
+    vizType = "kpi"
+  } else if (groupBy === "course_code") {
+    vizType = "table"
+  }
+
+  // Map to actual database columns
+  const actualMetricColumn = metric ? SCHEMA_CONFIG.metricColumnMap[metric as keyof typeof SCHEMA_CONFIG.metricColumnMap] : undefined
+  const actualGroupByColumn = groupBy ? SCHEMA_CONFIG.groupByColumnMap[groupBy as keyof typeof SCHEMA_CONFIG.groupByColumnMap] : undefined
+  
+  // Generate SQL with actual schema
+  const selectClause = actualGroupByColumn
+    ? actualMetricColumn && actualMetricColumn !== "COUNT(*)"
+      ? `${actualGroupByColumn}, AVG(${actualMetricColumn}) as ${metric}`
+      : `${actualGroupByColumn}, COUNT(*) as count`
+    : actualMetricColumn
+      ? actualMetricColumn === "COUNT(*)" 
+        ? "COUNT(*) as count"
+        : `AVG(${actualMetricColumn}) as ${metric}`
+      : "COUNT(*) as count"
+
+  // Map filter keys to actual column names
+  const actualFilters: Record<string, any> = {}
+  Object.entries(filters).forEach(([key, value]) => {
+    const actualKey = SCHEMA_CONFIG.groupByColumnMap[key as keyof typeof SCHEMA_CONFIG.groupByColumnMap] || key
+    actualFilters[actualKey] = value
+  })
+
+  const whereClause = Object.entries(actualFilters)
+    .map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return `${key} IN (${value.map((v) => `'${v}'`).join(", ")})`
+      }
+      return `${key} = '${value}'`
+    })
+    .join(" AND ")
+
+  const groupByClause = actualGroupByColumn ? `GROUP BY ${actualGroupByColumn}` : ""
+  const orderByColumn = actualGroupByColumn || (actualMetricColumn && actualMetricColumn !== "COUNT(*)" ? actualMetricColumn : "count")
+
+  // Get database name for institution
+  const dbName = SCHEMA_CONFIG.institutionDbMap[institutionCode as keyof typeof SCHEMA_CONFIG.institutionDbMap] || institutionCode
+  const tableName = SCHEMA_CONFIG.mainTable
+
+  const sql = `SELECT ${selectClause}
+FROM \`${dbName}\`.${tableName}
+${whereClause ? `WHERE ${whereClause}` : ""}
+${groupByClause}
+ORDER BY ${orderByColumn}`.trim()
+
+  const queryParams = new URLSearchParams()
+
+  // Add limit parameter
+  queryParams.append("limit", "1000")
+  queryParams.append("offset", "0")
+
+  // Convert filters to query parameters
+  if (filters && Object.keys(filters).length > 0) {
+    Object.entries(filters).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        // For array values, add multiple parameters with the same key
+        value.forEach((v) => queryParams.append(key, String(v)))
+      } else {
+        queryParams.append(key, String(value))
+      }
+    })
+  }
+
+  const queryString = `https://schools.syntex-ai.com/${institutionCode}/analysis-ready?${queryParams.toString()}`
+
+  return {
+    metric,
+    groupBy,
+    filters: Object.keys(filters).length > 0 ? filters : undefined,
+    timeHint,
+    vizType,
+    sql,
+    queryString,
+  }
+}

--- a/codebenders-dashboard/lib/query-executor.ts
+++ b/codebenders-dashboard/lib/query-executor.ts
@@ -1,0 +1,143 @@
+import type { QueryPlan, QueryResult } from "./types"
+
+const API_BASE_URL = "https://schools.syntex-ai.com"
+
+export async function executeQuery(
+  plan: QueryPlan,
+  institutionCode: string,
+  useDirectDB = false,
+): Promise<QueryResult> {
+  try {
+    console.log("[v0] Executing query for institution:", institutionCode)
+    console.log("[v0] Query plan:", plan)
+    console.log("[v0] Using direct DB:", useDirectDB)
+
+    if (useDirectDB) {
+      return await executeDirectDB(plan, institutionCode)
+    }
+
+    const url = plan.queryString
+    console.log("[v0] Fetching from:", url)
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status}`)
+    }
+
+    const data: any[] = await response.json()
+    console.log("[v0] Received data:", data.length, "records")
+
+    // If no groupBy, return raw data or single aggregate
+    if (!plan.groupBy) {
+      if (plan.metric && data.length > 0) {
+        const value = calculateAggregate(data, plan.metric)
+        return {
+          data: [{ [plan.metric]: value }],
+          rowCount: 1,
+        }
+      }
+      return {
+        data: data.slice(0, 100),
+        rowCount: data.length,
+      }
+    }
+
+    if (data.length > 0 && plan.groupBy in data[0]) {
+      const grouped = groupBy(data, plan.groupBy)
+      console.log("[v0] Grouped into", Object.keys(grouped).length, "groups")
+
+      const results = Object.entries(grouped).map(([key, records]) => {
+        const result: Record<string, any> = {
+          [plan.groupBy!]: key,
+        }
+
+        if (plan.metric) {
+          result[plan.metric] = calculateAggregate(records, plan.metric)
+        } else {
+          result.count = records.length
+        }
+
+        return result
+      })
+
+      results.sort((a, b) => {
+        const aVal = a[plan.groupBy!]
+        const bVal = b[plan.groupBy!]
+        if (typeof aVal === "string" && typeof bVal === "string") {
+          return aVal.localeCompare(bVal)
+        }
+        return aVal < bVal ? -1 : aVal > bVal ? 1 : 0
+      })
+
+      console.log("[v0] Final results:", results)
+
+      return {
+        data: results,
+        rowCount: results.length,
+      }
+    }
+
+    return {
+      data: data.slice(0, 100),
+      rowCount: data.length,
+    }
+  } catch (error) {
+    console.error("[v0] Query execution error:", error)
+    throw error
+  }
+}
+
+async function executeDirectDB(plan: QueryPlan, institutionCode: string): Promise<QueryResult> {
+  console.log("[v0] Executing SQL directly:", plan.sql)
+
+  const response = await fetch("/api/execute-sql", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      sql: plan.sql,
+      institution: institutionCode,
+    }),
+  })
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(error.details || "Database query failed")
+  }
+
+  const result = await response.json()
+  console.log("[v0] Direct DB returned:", result.rowCount, "records")
+
+  return {
+    data: result.data,
+    rowCount: result.rowCount,
+  }
+}
+
+function groupBy(data: any[], field: string): Record<string, any[]> {
+  return data.reduce(
+    (acc, record) => {
+      const key = String(record[field] ?? "Unknown")
+      if (!acc[key]) {
+        acc[key] = []
+      }
+      acc[key].push(record)
+      return acc
+    },
+    {} as Record<string, any[]>,
+  )
+}
+
+function calculateAggregate(records: any[], metric: string): number {
+  if (records.length === 0) return 0
+
+  const values = records.map((r) => Number(r[metric])).filter((v) => !isNaN(v))
+
+  if (values.length === 0) {
+    return records.length
+  }
+
+  const sum = values.reduce((acc, val) => acc + val, 0)
+  const avg = sum / values.length
+
+  return Math.round(avg * 100) / 100
+}

--- a/codebenders-dashboard/lib/types.ts
+++ b/codebenders-dashboard/lib/types.ts
@@ -1,0 +1,28 @@
+export interface QueryPlan {
+  metric?: string
+  groupBy?: string
+  filters?: Record<string, any>
+  timeHint?: string
+  vizType: "line" | "bar" | "pie" | "kpi" | "table"
+  sql: string
+  queryString: string
+}
+
+export interface QueryResult {
+  data: Record<string, any>[]
+  rowCount: number
+}
+
+export interface PDPRecord {
+  student_id: string
+  institution: string
+  cohort: string
+  term: string
+  program: string
+  course_code: string
+  enrollment_status: string
+  retention_rate: number
+  completion_rate: number
+  gpa: number
+  credits_earned: number
+}

--- a/codebenders-dashboard/lib/utils.ts
+++ b/codebenders-dashboard/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/codebenders-dashboard/package.json
+++ b/codebenders-dashboard/package.json
@@ -17,8 +17,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "0.548.0",
-    "mysql2": "3.15.3",
     "next": "16.0.1",
+    "pg": "^8.18.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "recharts": "^2.15.0",
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "24.9.2",
+    "@types/pg": "^8.16.0",
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.2",
     "postcss": "8.5.6",


### PR DESCRIPTION
## Summary
- Create `lib/db.ts` — singleton `pg` Pool with env-var config, conditional SSL, and required-var guard
- Replace `mysql2` with `pg` in `package.json`; move `@types/pg` to `devDependencies`
- Update `.gitignore` to allow `codebenders-dashboard/lib/` to be tracked (was caught by Python `lib/` ignore pattern)
- Also commits existing `lib/` files that were previously untracked: `prompt-analyzer.ts`, `query-executor.ts`, `types.ts`, `utils.ts`

## Known intermediate state
The `mysql2` import removal from `package.json` means the branch has broken imports in 5 API route files until Tasks 7-8 migrate them to `pg`. This is intentional — do not run `npm install` standalone on this branch.

## Test plan
- [x] `@types/pg` is in `devDependencies`
- [x] `mysql2` is absent from both `dependencies` and `devDependencies`
- [x] `lib/db.ts` throws a clear error if `DB_HOST`/`DB_USER`/`DB_PASSWORD` are missing
- [ ] `npm run build` passes after Tasks 7-8 complete the mysql2 → pg migration

Closes #37