### PR TITLE
Task 7: Migrate dashboard API routes from mysql2 to pg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ lerna-debug.log*
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+
+# Exceptions: dashboard source files that conflict with Python ignores above
+!codebenders-dashboard/lib/
+!codebenders-dashboard/lib/**
+
 dist/
 dist-ssr/
 *.local

--- a/codebenders-dashboard/app/api/dashboard/kpis/route.ts
+++ b/codebenders-dashboard/app/api/dashboard/kpis/route.ts
@@ -1,42 +1,23 @@
 import { type NextRequest, NextResponse } from "next/server"
-import mysql from "mysql2/promise"
-
-let pool: mysql.Pool | null = null
-
-function getPool() {
-  if (!pool) {
-    pool = mysql.createPool({
-      host: process.env.DB_HOST,
-      user: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      port: Number.parseInt(process.env.DB_PORT || "3306"),
-      database: process.env.DB_NAME || "pdp_analytics",
-      waitForConnections: true,
-      connectionLimit: 10,
-      queueLimit: 0,
-    })
-  }
-  return pool
-}
+import { getPool } from "@/lib/db"
 
 export async function GET(request: NextRequest) {
   try {
     const pool = getPool()
-    
-    // Query for KPI metrics
+
     const sql = `
-      SELECT 
-        AVG(Retention) * 100 as overall_retention_rate,
+      SELECT
+        AVG(retention) * 100 as overall_retention_rate,
         AVG(retention_probability) * 100 as avg_predicted_retention,
         SUM(CASE WHEN at_risk_alert IN ('HIGH', 'URGENT') THEN 1 ELSE 0 END) as high_critical_risk_count,
         AVG(course_completion_rate) * 100 as avg_course_completion_rate,
         COUNT(*) as total_students
-      FROM student_predictions
+      FROM student_level_with_predictions
       LIMIT 1
     `
 
-    const [rows] = await pool.query(sql)
-    const kpis = (Array.isArray(rows) && rows.length > 0 ? rows[0] : null) as any
+    const result = await pool.query(sql)
+    const kpis = result.rows[0] ?? null
 
     if (!kpis) {
       return NextResponse.json({ error: "No data found" }, { status: 404 })
@@ -60,4 +41,3 @@ export async function GET(request: NextRequest) {
     )
   }
 }
-

--- a/codebenders-dashboard/app/api/dashboard/readiness/route.ts
+++ b/codebenders-dashboard/app/api/dashboard/readiness/route.ts
@@ -1,51 +1,40 @@
-import { NextResponse } from 'next/server';
-import mysql from 'mysql2/promise';
-
-const dbConfig = {
-  host: process.env.DB_HOST || 'devcolor00.czqeeakaypfi.us-west-2.rds.amazonaws.com',
-  user: process.env.DB_USER || 'admin',
-  password: process.env.DB_PASSWORD || 'devcolor2025',
-  database: process.env.DB_NAME || 'Kentucky_Community_and_Technical_College_System',
-  port: parseInt(process.env.DB_PORT || '3306'),
-};
+import { NextResponse } from "next/server"
+import { getPool } from "@/lib/db"
 
 export async function GET(request: Request) {
-  let connection;
-  
   try {
-    const { searchParams } = new URL(request.url);
-    const institution = searchParams.get('institution');
-    const cohort = searchParams.get('cohort');
-    const level = searchParams.get('level'); // high, medium, low
-    
-    connection = await mysql.createConnection(dbConfig);
-    
-    // Build WHERE clause
-    const conditions: string[] = [];
-    const params: any[] = [];
-    
+    const { searchParams } = new URL(request.url)
+    const institution = searchParams.get("institution")
+    const cohort = searchParams.get("cohort")
+    const level = searchParams.get("level") // high, medium, low
+
+    const pool = getPool()
+
+    // Build WHERE clause with $N Postgres placeholders
+    const conditions: string[] = []
+    const params: any[] = []
+
     if (institution) {
-      conditions.push('Institution_ID = ?');
-      params.push(institution);
+      params.push(institution)
+      conditions.push(`"Institution_ID" = $${params.length}`)
     }
-    
+
     if (cohort) {
-      conditions.push('Cohort = ?');
-      params.push(cohort);
+      params.push(cohort)
+      conditions.push(`"Cohort" = $${params.length}`)
     }
-    
+
     if (level) {
-      conditions.push('readiness_level = ?');
-      params.push(level);
+      params.push(level)
+      conditions.push(`readiness_level = $${params.length}`)
     }
-    
-    const whereClause = conditions.length > 0 
-      ? `WHERE ${conditions.join(' AND ')}` 
-      : '';
-    
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
+
     // Get overall statistics
-    const [statsRows] = await connection.execute(`
-      SELECT 
+    const statsResult = await pool.query(
+      `
+      SELECT
         COUNT(*) as total_students,
         AVG(readiness_score) as avg_score,
         MIN(readiness_score) as min_score,
@@ -55,13 +44,20 @@ export async function GET(request: Request) {
         SUM(CASE WHEN readiness_level = 'low' THEN 1 ELSE 0 END) as low_count
       FROM llm_recommendations
       ${whereClause}
-    `, params);
-    
-    const stats = (statsRows as any[])[0];
-    
+    `,
+      params
+    )
+
+    const stats = statsResult.rows[0]
+
+    if (!stats) {
+      return NextResponse.json({ success: true, data: null }, { status: 200 })
+    }
+
     // Get distribution by readiness level
-    const [distributionRows] = await connection.execute(`
-      SELECT 
+    const distributionResult = await pool.query(
+      `
+      SELECT
         readiness_level,
         COUNT(*) as count,
         AVG(readiness_score) as avg_score,
@@ -70,18 +66,21 @@ export async function GET(request: Request) {
       FROM llm_recommendations
       ${whereClause}
       GROUP BY readiness_level
-      ORDER BY 
+      ORDER BY
         CASE readiness_level
           WHEN 'high' THEN 1
           WHEN 'medium' THEN 2
           WHEN 'low' THEN 3
         END
-    `, params);
-    
+    `,
+      params
+    )
+
     // Get score distribution (buckets)
-    const [scoreDistRows] = await connection.execute(`
-      SELECT 
-        CASE 
+    const scoreDistResult = await pool.query(
+      `
+      SELECT
+        CASE
           WHEN readiness_score >= 0.8 THEN '0.8-1.0'
           WHEN readiness_score >= 0.6 THEN '0.6-0.8'
           WHEN readiness_score >= 0.4 THEN '0.4-0.6'
@@ -91,18 +90,28 @@ export async function GET(request: Request) {
         COUNT(*) as count
       FROM llm_recommendations
       ${whereClause}
-      GROUP BY score_range
+      GROUP BY
+        CASE
+          WHEN readiness_score >= 0.8 THEN '0.8-1.0'
+          WHEN readiness_score >= 0.6 THEN '0.6-0.8'
+          WHEN readiness_score >= 0.4 THEN '0.4-0.6'
+          WHEN readiness_score >= 0.2 THEN '0.2-0.4'
+          ELSE '0.0-0.2'
+        END
       ORDER BY score_range DESC
-    `, params);
-    
+    `,
+      params
+    )
+
     // Get recent assessments with student details
-    const [recentRows] = await connection.execute(`
-      SELECT 
+    const recentResult = await pool.query(
+      `
+      SELECT
         lr.id,
-        lr.Student_GUID,
-        lr.Institution_ID,
-        lr.Cohort,
-        lr.Cohort_Term,
+        lr."Student_GUID",
+        lr."Institution_ID",
+        lr."Cohort",
+        lr."Cohort_Term",
         lr.readiness_score,
         lr.readiness_level,
         lr.rationale,
@@ -114,52 +123,56 @@ export async function GET(request: Request) {
       ${whereClause}
       ORDER BY lr.generated_at DESC
       LIMIT 100
-    `, params);
-    
+    `,
+      params
+    )
+
     // Parse JSON fields in recent assessments
-    const assessments = (recentRows as any[]).map(row => ({
+    const assessments = recentResult.rows.map((row) => ({
       ...row,
       risk_factors: row.risk_factors ? JSON.parse(row.risk_factors) : [],
-      suggested_actions: row.suggested_actions ? JSON.parse(row.suggested_actions) : []
-    }));
-    
+      suggested_actions: row.suggested_actions ? JSON.parse(row.suggested_actions) : [],
+    }))
+
     // Get most common risk factors
-    const [riskFactorRows] = await connection.execute(`
-      SELECT 
-        risk_factors
+    const riskFactorResult = await pool.query(
+      `
+      SELECT risk_factors
       FROM llm_recommendations
       ${whereClause}
-    `, params);
-    
+    `,
+      params
+    )
+
     // Parse and count risk factors
-    const riskFactorCounts: { [key: string]: number } = {};
-    (riskFactorRows as any[]).forEach(row => {
+    const riskFactorCounts: { [key: string]: number } = {}
+    riskFactorResult.rows.forEach((row) => {
       if (row.risk_factors) {
         try {
-          const factors = JSON.parse(row.risk_factors);
+          const factors = JSON.parse(row.risk_factors)
           if (Array.isArray(factors)) {
-            factors.forEach(factor => {
-              // Truncate long factors for grouping
-              const truncated = factor.substring(0, 100);
-              riskFactorCounts[truncated] = (riskFactorCounts[truncated] || 0) + 1;
-            });
+            factors.forEach((factor) => {
+              const truncated = factor.substring(0, 100)
+              riskFactorCounts[truncated] = (riskFactorCounts[truncated] || 0) + 1
+            })
           }
         } catch (e) {
           // Skip invalid JSON
         }
       }
-    });
-    
+    })
+
     // Sort and get top 10 risk factors
     const topRiskFactors = Object.entries(riskFactorCounts)
       .sort((a, b) => b[1] - a[1])
       .slice(0, 10)
-      .map(([factor, count]) => ({ factor, count }));
-    
+      .map(([factor, count]) => ({ factor, count }))
+
     // Get cohort breakdown
-    const [cohortRows] = await connection.execute(`
-      SELECT 
-        Cohort,
+    const cohortResult = await pool.query(
+      `
+      SELECT
+        "Cohort",
         COUNT(*) as total,
         AVG(readiness_score) as avg_score,
         SUM(CASE WHEN readiness_level = 'high' THEN 1 ELSE 0 END) as high_count,
@@ -167,12 +180,12 @@ export async function GET(request: Request) {
         SUM(CASE WHEN readiness_level = 'low' THEN 1 ELSE 0 END) as low_count
       FROM llm_recommendations
       ${whereClause}
-      GROUP BY Cohort
-      ORDER BY Cohort DESC
-    `, params);
-    
-    await connection.end();
-    
+      GROUP BY "Cohort"
+      ORDER BY "Cohort" DESC
+    `,
+      params
+    )
+
     return NextResponse.json({
       success: true,
       data: {
@@ -183,31 +196,25 @@ export async function GET(request: Request) {
           max_score: parseFloat(stats.max_score || 0).toFixed(4),
           high_count: stats.high_count,
           medium_count: stats.medium_count,
-          low_count: stats.low_count
+          low_count: stats.low_count,
         },
-        distribution: distributionRows,
-        score_distribution: scoreDistRows,
+        distribution: distributionResult.rows,
+        score_distribution: scoreDistResult.rows,
         assessments: assessments,
         top_risk_factors: topRiskFactors,
-        cohort_breakdown: cohortRows
-      }
-    });
-    
+        cohort_breakdown: cohortResult.rows,
+      },
+    })
   } catch (error) {
-    console.error('Database error:', error);
-    
-    if (connection) {
-      await connection.end();
-    }
-    
+    console.error("Database error:", error)
+
     return NextResponse.json(
-      { 
-        success: false, 
-        error: 'Failed to fetch readiness assessment data',
-        details: error instanceof Error ? error.message : 'Unknown error'
+      {
+        success: false,
+        error: "Failed to fetch readiness assessment data",
+        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
-    );
+    )
   }
 }
-

--- a/codebenders-dashboard/app/api/dashboard/retention-risk/route.ts
+++ b/codebenders-dashboard/app/api/dashboard/retention-risk/route.ts
@@ -1,38 +1,19 @@
 import { type NextRequest, NextResponse } from "next/server"
-import mysql from "mysql2/promise"
-
-let pool: mysql.Pool | null = null
-
-function getPool() {
-  if (!pool) {
-    pool = mysql.createPool({
-      host: process.env.DB_HOST,
-      user: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      port: Number.parseInt(process.env.DB_PORT || "3306"),
-      database: process.env.DB_NAME || "pdp_analytics",
-      waitForConnections: true,
-      connectionLimit: 10,
-      queueLimit: 0,
-    })
-  }
-  return pool
-}
+import { getPool } from "@/lib/db"
 
 export async function GET(request: NextRequest) {
   try {
     const pool = getPool()
-    
-    // Query for retention risk category distribution
+
     const sql = `
-      SELECT 
+      SELECT
         retention_risk_category as category,
         COUNT(*) as count,
-        ROUND(COUNT(*) * 100.0 / (SELECT COUNT(*) FROM student_predictions), 1) as percentage
-      FROM student_predictions
+        ROUND(COUNT(*) * 100.0 / (SELECT COUNT(*) FROM student_level_with_predictions), 1) as percentage
+      FROM student_level_with_predictions
       WHERE retention_risk_category IS NOT NULL
       GROUP BY retention_risk_category
-      ORDER BY 
+      ORDER BY
         CASE retention_risk_category
           WHEN 'Critical Risk' THEN 1
           WHEN 'High Risk' THEN 2
@@ -42,10 +23,10 @@ export async function GET(request: NextRequest) {
         END
     `
 
-    const [rows] = await pool.query(sql)
-    
+    const result = await pool.query(sql)
+
     return NextResponse.json({
-      data: Array.isArray(rows) ? rows : [],
+      data: result.rows,
     })
   } catch (error) {
     console.error("Retention risk fetch error:", error)
@@ -58,4 +39,3 @@ export async function GET(request: NextRequest) {
     )
   }
 }
-

--- a/codebenders-dashboard/app/api/dashboard/risk-alerts/route.ts
+++ b/codebenders-dashboard/app/api/dashboard/risk-alerts/route.ts
@@ -1,38 +1,19 @@
 import { type NextRequest, NextResponse } from "next/server"
-import mysql from "mysql2/promise"
-
-let pool: mysql.Pool | null = null
-
-function getPool() {
-  if (!pool) {
-    pool = mysql.createPool({
-      host: process.env.DB_HOST,
-      user: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      port: Number.parseInt(process.env.DB_PORT || "3306"),
-      database: process.env.DB_NAME || "pdp_analytics",
-      waitForConnections: true,
-      connectionLimit: 10,
-      queueLimit: 0,
-    })
-  }
-  return pool
-}
+import { getPool } from "@/lib/db"
 
 export async function GET(request: NextRequest) {
   try {
     const pool = getPool()
-    
-    // Query for risk alert distribution
+
     const sql = `
-      SELECT 
+      SELECT
         at_risk_alert as category,
         COUNT(*) as count,
-        ROUND(COUNT(*) * 100.0 / (SELECT COUNT(*) FROM student_predictions), 1) as percentage
-      FROM student_predictions
+        ROUND(COUNT(*) * 100.0 / (SELECT COUNT(*) FROM student_level_with_predictions), 1) as percentage
+      FROM student_level_with_predictions
       WHERE at_risk_alert IS NOT NULL
       GROUP BY at_risk_alert
-      ORDER BY 
+      ORDER BY
         CASE at_risk_alert
           WHEN 'URGENT' THEN 1
           WHEN 'HIGH' THEN 2
@@ -42,10 +23,10 @@ export async function GET(request: NextRequest) {
         END
     `
 
-    const [rows] = await pool.query(sql)
-    
+    const result = await pool.query(sql)
+
     return NextResponse.json({
-      data: Array.isArray(rows) ? rows : [],
+      data: result.rows,
     })
   } catch (error) {
     console.error("Risk alerts fetch error:", error)
@@ -58,4 +39,3 @@ export async function GET(request: NextRequest) {
     )
   }
 }
-

--- a/codebenders-dashboard/app/api/execute-sql/route.ts
+++ b/codebenders-dashboard/app/api/execute-sql/route.ts
@@ -1,80 +1,29 @@
 import { type NextRequest, NextResponse } from "next/server"
-import mysql from "mysql2/promise"
-
-// Create a connection pool for better performance
-let pool: mysql.Pool | null = null
-
-function getPool() {
-  if (!pool) {
-    console.log("[v0] Creating database pool with config:", {
-      host: process.env.DB_HOST,
-      user: process.env.DB_USER,
-      port: process.env.DB_PORT || "3306",
-      database: process.env.DB_NAME || "University_of_Akron",
-      hasPassword: !!process.env.DB_PASSWORD,
-    })
-    
-    pool = mysql.createPool({
-      host: process.env.DB_HOST,
-      user: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      port: Number.parseInt(process.env.DB_PORT || "3306"),
-      database: process.env.DB_NAME || "pdp_analytics",
-      waitForConnections: true,
-      connectionLimit: 10,
-      queueLimit: 0,
-    })
-    
-    console.log("[v0] Database pool created successfully")
-  }
-  return pool
-}
+import { getPool } from "@/lib/db"
 
 export async function POST(request: NextRequest) {
   try {
-    const { sql, institution } = await request.json()
+    const { sql } = await request.json()
 
     if (!sql) {
       return NextResponse.json({ error: "SQL query is required" }, { status: 400 })
     }
 
-    console.log("[v0] Executing SQL:", sql)
-
     const pool = getPool()
-    
-    // Test the connection first
-    try {
-      console.log("[v0] Testing database connection...")
-      const connection = await pool.getConnection()
-      console.log("[v0] Database connection successful!")
-      connection.release()
-    } catch (connError) {
-      console.error("[v0] Database connection failed:", connError)
-      throw new Error(`Database connection failed: ${connError instanceof Error ? connError.message : String(connError)}`)
-    }
-    
-    console.log("[v0] Executing query...")
-    const [rows] = await pool.query(sql)
-
-    console.log("[v0] Query returned:", Array.isArray(rows) ? rows.length : 0, "records")
+    const result = await pool.query(sql)
 
     return NextResponse.json({
-      data: rows,
-      rowCount: Array.isArray(rows) ? rows.length : 0,
+      data: result.rows,
+      rowCount: result.rowCount ?? result.rows.length,
     })
   } catch (error) {
-    console.error("[v0] SQL execution error:", error)
-    console.error("[v0] Error details:", {
-      name: error instanceof Error ? error.name : 'Unknown',
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    })
+    console.error("SQL execution error:", error)
     return NextResponse.json(
       {
         error: "Database query failed",
         details: error instanceof Error ? error.message : String(error),
       },
-      { status: 500 },
+      { status: 500 }
     )
   }
 }

--- a/codebenders-dashboard/env.example
+++ b/codebenders-dashboard/env.example
@@ -1,10 +1,12 @@
-# Database Configuration
-DB_HOST=your-db-host-here
-DB_USER=your-db-user
-DB_PASSWORD=your-db-password
-DB_PORT=3306
-DB_NAME=pdp_analytics
+# Database Configuration (Supabase Postgres)
+# Local development (supabase start)
+DB_HOST=127.0.0.1
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_PORT=54332
+DB_NAME=postgres
+# Set DB_SSL=true for hosted Supabase; leave false or unset for local dev
+DB_SSL=false
 
 # OpenAI Configuration (for AI-powered query generation)
 OPENAI_API_KEY=your-openai-api-key-here
-

--- a/codebenders-dashboard/lib/db.ts
+++ b/codebenders-dashboard/lib/db.ts
@@ -1,0 +1,23 @@
+import { Pool } from "pg"
+
+let pool: Pool | null = null
+
+export function getPool(): Pool {
+  if (!pool) {
+    if (!process.env.DB_HOST || !process.env.DB_USER || !process.env.DB_PASSWORD) {
+      throw new Error(
+        "Missing required database environment variables: DB_HOST, DB_USER, DB_PASSWORD"
+      )
+    }
+    pool = new Pool({
+      host: process.env.DB_HOST,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      port: Number.parseInt(process.env.DB_PORT || "54332"),
+      database: process.env.DB_NAME || "postgres",
+      ssl: process.env.DB_SSL === "true" ? { rejectUnauthorized: false } : false,
+      max: 10,
+    })
+  }
+  return pool
+}

--- a/codebenders-dashboard/package.json
+++ b/codebenders-dashboard/package.json
@@ -17,8 +17,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "0.548.0",
-    "mysql2": "3.15.3",
     "next": "16.0.1",
+    "pg": "^8.18.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "recharts": "^2.15.0",
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "24.9.2",
+    "@types/pg": "^8.16.0",
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.2",
     "postcss": "8.5.6",


### PR DESCRIPTION
## Summary
- Replace local mysql2 pool setup with shared `getPool()` from `@/lib/db` in all 4 dashboard routes
- Migrate `execute-sql/route.ts` to pg (build was broken since mysql2 removed from package.json)
- Switch result access from mysql2's `[rows]` destructuring to pg's `result.rows`
- Convert `readiness/route.ts`: `createConnection` + `?` params → pool + `$N` params
- Remove hardcoded AWS RDS credentials from `readiness/route.ts`
- Add `pg` to `dependencies`, `@types/pg` to `devDependencies`, remove `mysql2` from `package.json`
- Fix `GROUP BY score_range` alias (MySQL-only) → repeat full `CASE` expression for Postgres compatibility
- Add null guard for empty `stats` result in readiness route
- Fix `db.ts` default port fallback: `6543` → `54332` (local Supabase direct port)
- Update `env.example`: correct port to `54332`, add `DB_SSL` variable with documentation
- Correct table name: `student_predictions` → `student_level_with_predictions`
- Remove `[v0]` debug log tags from `execute-sql/route.ts`

## Test plan
- [x] Zero TypeScript diagnostics across all routes
- [x] Two code review passes — all critical/important issues addressed
- [ ] Load data via ML pipeline, verify `/api/dashboard/kpis` returns correct counts
- [ ] Verify `/api/dashboard/risk-alerts` and `/api/dashboard/retention-risk` return data
- [ ] POST to `/api/execute-sql` with a valid query, verify rows returned

Closes #38