### PR TITLE
feat: rebrand frontend UI from KCTCS to Bishop State

### DIFF
--- a/codebenders-dashboard/app/layout.tsx
+++ b/codebenders-dashboard/app/layout.tsx
@@ -13,8 +13,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "KCTCS Student Success Dashboard",
-  description: "AI-Powered Student Success Analytics & Predictive Models for KCTCS",
+  title: "Bishop State Student Success Dashboard",
+  description: "AI-Powered Student Success Analytics & Predictive Models for Bishop State Community College",
 };
 
 export default function RootLayout({

--- a/codebenders-dashboard/app/page.tsx
+++ b/codebenders-dashboard/app/page.tsx
@@ -131,7 +131,7 @@ export default function DashboardPage() {
               Student Success Dashboard
             </h1>
             <p className="text-muted-foreground mt-2">
-              KCTCS Student Analytics & Predictive Models
+              Bishop State Community College Student Analytics & Predictive Models
             </p>
           </div>
           <div className="flex gap-2">

--- a/codebenders-dashboard/app/query/page.tsx
+++ b/codebenders-dashboard/app/query/page.tsx
@@ -16,8 +16,7 @@ import Link from "next/link"
 import { ArrowLeft } from "lucide-react"
 
 const INSTITUTIONS = [
-  { name: "KCTCS", code: "kctcs" },
-  { name: "Bishop State", code: "al" },
+  { name: "Bishop State", code: "bscc" },
   { name: "University of Akron", code: "oh" },
   { name: "Cal State San Bernardino", code: "csusb" },
   { name: "Thomas More University", code: "ky" },

--- a/codebenders-dashboard/components/export-button.tsx
+++ b/codebenders-dashboard/components/export-button.tsx
@@ -74,7 +74,7 @@ export function ExportButton({ data, disabled = false }: ExportButtonProps) {
     
     const exportData = {
       generated: new Date().toISOString(),
-      institution: "KCTCS",
+      institution: "Bishop State Community College",
       kpis: data.kpis,
       riskAlerts: data.riskAlerts,
       retentionRisk: data.retentionRisk,
@@ -103,7 +103,7 @@ export function ExportButton({ data, disabled = false }: ExportButtonProps) {
     md.push("# Student Success Dashboard Report")
     md.push("")
     md.push(`**Generated:** ${new Date().toLocaleString()}`)
-    md.push(`**Institution:** KCTCS`)
+    md.push(`**Institution:** Bishop State Community College`)
     md.push(`**Data Source:** student_predictions table (${data.kpis?.totalStudents?.toLocaleString()} students)`)
     md.push("")
     md.push("---")


### PR DESCRIPTION
Closes #40

## Summary
- Update page title/description metadata to Bishop State branding
- Update dashboard subtitle text
- Remove KCTCS from institutions dropdown; fix Bishop State institution code `"al"` → `"bscc"` to align with backend routing in `prompt-analyzer.ts` and `analyze/route.ts`
- Update institution name in export-button.tsx (JSON and markdown exports)

## Test plan
- [ ] Dashboard page subtitle shows "Bishop State Community College Student Analytics & Predictive Models"
- [ ] Browser tab title shows "Bishop State Student Success Dashboard"
- [ ] Query page institution dropdown defaults to "Bishop State" with no KCTCS option
- [ ] Export Report → JSON contains `"institution": "Bishop State Community College"`
- [ ] Export Report → Markdown contains `**Institution:** Bishop State Community College`