### PR TITLE
feat: update methodology page — remove impl refs, add worked examples

### DIFF
--- a/codebenders-dashboard/app/api/analyze/route.ts
+++ b/codebenders-dashboard/app/api/analyze/route.ts
@@ -18,50 +18,55 @@ const queryPlanSchema = z.object({
 })
 
 // Database schema configuration
+// IMPORTANT: Column names listed here are the EXACT case-sensitive names in PostgreSQL.
+// Mixed-case columns (e.g. "Cohort", "Retention") must be double-quoted in generated SQL.
+// All-lowercase columns (e.g. retention_probability) do not require quoting.
 const SCHEMA_INFO = {
   bscc: {
     database: "postgres",
     mainTable: "student_level_with_predictions",
     description: "Bishop State Community College student cohort data with retention, persistence, and completion metrics",
     columns: {
-      // Key dimensions
-      cohort: "Cohort year (numeric: 2019, 2020, etc.)",
-      cohort_term: "Term of cohort entry (Fall, Spring, Summer)",
-      student_guid: "Unique student identifier",
-      institution_id: "Institution identifier (102030 for Bishop State)",
+      // Key dimensions — MIXED CASE: must be double-quoted in SQL
+      Cohort: "Cohort year (numeric: 2019, 2020, etc.) — write as \"Cohort\"",
+      Cohort_Term: "Term of cohort entry (Fall, Spring, Summer) — write as \"Cohort_Term\"",
+      Student_GUID: "Unique student identifier — write as \"Student_GUID\"",
+      Institution_ID: "Institution identifier (102030 for Bishop State) — write as \"Institution_ID\"",
 
-      // Demographics
-      gender: "Student gender",
-      race: "Student race/ethnicity",
-      student_age: "Age of student",
-      first_gen: "First generation status",
+      // Demographics — MIXED CASE: must be double-quoted in SQL
+      Gender: "Student gender — write as \"Gender\"",
+      Race: "Student race/ethnicity — write as \"Race\"",
+      Student_Age: "Age of student (integer) — write as \"Student_Age\"",
+      First_Gen: "First generation status — write as \"First_Gen\"",
 
-      // Academic info
-      enrollment_type: "Type of enrollment",
-      enrollment_intensity_first_term: "Enrollment intensity in first term (Full-Time, Part-Time)",
-      program_of_study_year_1: "Program of study in year 1 (CIP code)",
-      credential_type_sought_year_1: "Credential type being pursued",
+      // Academic info — MIXED CASE: must be double-quoted in SQL
+      Enrollment_Type: "Type of enrollment — write as \"Enrollment_Type\"",
+      Enrollment_Intensity_First_Term: "Enrollment intensity in first term (Full-Time, Part-Time) — write as \"Enrollment_Intensity_First_Term\"",
+      Program_of_Study_Year_1: "Program of study in year 1 (CIP code) — write as \"Program_of_Study_Year_1\"",
+      Credential_Type_Sought_Year_1: "Credential type being pursued — write as \"Credential_Type_Sought_Year_1\"",
+      Math_Placement: "Math placement level (C=college-level, R=remedial, N=none) — write as \"Math_Placement\"",
 
-      // Performance metrics
-      retention: "Retention indicator (0 or 1)",
-      persistence: "Persistence indicator (0 or 1)",
-      gpa_group_year_1: "GPA in year 1",
-      gpa_group_term_1: "GPA in term 1",
+      // Performance metrics — MIXED CASE: must be double-quoted in SQL
+      Retention: "Retention indicator (0 or 1) — write as \"Retention\"",
+      Persistence: "Persistence indicator (0 or 1) — write as \"Persistence\"",
+      GPA_Group_Year_1: "GPA in year 1 — write as \"GPA_Group_Year_1\"",
+      GPA_Group_Term_1: "GPA in term 1 — write as \"GPA_Group_Term_1\"",
 
-      // Credits
-      number_of_credits_attempted_year_1: "Credits attempted in year 1",
-      number_of_credits_earned_year_1: "Credits earned in year 1",
-      number_of_credits_attempted_year_2: "Credits attempted in year 2",
-      number_of_credits_earned_year_2: "Credits earned in year 2",
+      // Credits — MIXED CASE: must be double-quoted in SQL
+      Number_of_Credits_Attempted_Year_1: "Credits attempted in year 1 — write as \"Number_of_Credits_Attempted_Year_1\"",
+      Number_of_Credits_Earned_Year_1: "Credits earned in year 1 — write as \"Number_of_Credits_Earned_Year_1\"",
+      Number_of_Credits_Attempted_Year_2: "Credits attempted in year 2 — write as \"Number_of_Credits_Attempted_Year_2\"",
+      Number_of_Credits_Earned_Year_2: "Credits earned in year 2 — write as \"Number_of_Credits_Earned_Year_2\"",
 
-      // Completion metrics
-      time_to_credential: "Time to any credential",
+      // Completion metrics — MIXED CASE: must be double-quoted in SQL
+      Time_to_Credential: "Time to any credential — write as \"Time_to_Credential\"",
 
-      // ML predictions
+      // ML predictions — all lowercase: no quoting needed
       retention_probability: "Predicted probability of retention (0-1)",
       retention_risk_category: "Risk category (Low Risk, Moderate Risk, High Risk, Critical Risk)",
       at_risk_alert: "Early warning alert level (LOW, MODERATE, HIGH, URGENT)",
-      predicted_gpa: "ML-predicted GPA",
+      course_completion_rate: "Course completion rate (0-1)",
+      passing_rate: "Course passing rate (0-1)",
     },
   },
   akron: {
@@ -107,10 +112,14 @@ KEY COLUMNS:
 ${Object.entries(schemaInfo.columns).map(([col, desc]) => `- ${col}: ${desc}`).join("\n")}
 
 CRITICAL SCHEMA NOTES:
-- cohort: NUMERIC year only (e.g., 2019, 2020) — NOT a string like "2024-Fall"
-- cohort_term: Term name (e.g., "Fall", "Spring", "Summer")
-- To filter by "Fall 2023", use: WHERE cohort = 2023 AND cohort_term = 'Fall'
-- student_age: INTEGER field — use direct numeric comparisons (e.g., student_age >= 25)
+- Column names with uppercase letters MUST be double-quoted in PostgreSQL SQL or the query will fail.
+  CORRECT:   WHERE "Cohort" = 2023 AND "Cohort_Term" = 'Fall'
+  INCORRECT: WHERE cohort = 2023 AND cohort_term = 'Fall'
+- "Cohort": NUMERIC year only (e.g., 2019, 2020) — NOT a string like "2024-Fall"
+- "Cohort_Term": Term name (e.g., "Fall", "Spring", "Summer")
+- To filter by "Fall 2023", use: WHERE "Cohort" = 2023 AND "Cohort_Term" = 'Fall'
+- "Student_Age": INTEGER field — use direct numeric comparisons (e.g., "Student_Age" >= 25)
+- Lowercase ML columns (retention_probability, at_risk_alert, etc.) do NOT need quoting.
 - Use standard PostgreSQL syntax — no backtick quoting, no cross-database references
 
 IMPORTANT QUERY INTERPRETATION RULES:
@@ -118,28 +127,28 @@ IMPORTANT QUERY INTERPRETATION RULES:
 1. METRIC SELECTION:
    - ONLY include a metric if the user explicitly asks for retention, persistence, GPA, credits, etc.
    - If user asks to "segment", "compare", "show", "count", or "list" students → use COUNT(*) and NO specific metric
-   - "retention" → AVG(retention) as retention_rate
-   - "persistence" or "completion" → AVG(persistence) as completion_rate
-   - "GPA" → AVG(gpa_group_year_1) as gpa
-   - "credits" → AVG(number_of_credits_earned_year_1) as credits_earned
+   - "retention" → AVG("Retention") as retention_rate
+   - "persistence" or "completion" → AVG("Persistence") as completion_rate
+   - "GPA" → AVG("GPA_Group_Year_1") as gpa
+   - "credits" → AVG("Number_of_Credits_Earned_Year_1") as credits_earned
    - Otherwise → COUNT(*) as count
 
 2. GROUPING & SEGMENTATION:
    - "segment by X" or "compare X" → GROUP BY X column
    - "by age", "age groups", "segment by age" → Use CASE statement to create age groups:
      CASE
-       WHEN student_age < 25 THEN 'Under 25'
-       WHEN student_age >= 25 THEN '25 and Over'
+       WHEN "Student_Age" < 25 THEN 'Under 25'
+       WHEN "Student_Age" >= 25 THEN '25 and Over'
      END AS age_group
-   - "by gender" → GROUP BY gender
-   - "by race" → GROUP BY race
-   - "by cohort" → GROUP BY cohort
-   - "by term" → GROUP BY cohort_term
+   - "by gender" → GROUP BY "Gender"
+   - "by race" → GROUP BY "Race"
+   - "by cohort" → GROUP BY "Cohort"
+   - "by term" → GROUP BY "Cohort_Term"
 
 3. FILTERS:
-   - "2023 cohort" → WHERE cohort = 2023
-   - "Fall 2023" or "2023 Fall" → WHERE cohort = 2023 AND cohort_term = 'Fall'
-   - Age filters: use numeric comparisons directly (e.g., student_age >= 25)
+   - "2023 cohort" → WHERE "Cohort" = 2023
+   - "Fall 2023" or "2023 Fall" → WHERE "Cohort" = 2023 AND "Cohort_Term" = 'Fall'
+   - Age filters: use numeric comparisons directly (e.g., "Student_Age" >= 25)
 
 4. VISUALIZATION:
    - Comparing groups (age, gender, race) → "bar"
@@ -163,7 +172,7 @@ Generate a query plan with:
 EXAMPLE for "segment students over 25 and under 25 in 2023 cohort":
 {
   "vizType": "bar",
-  "sql": "SELECT CASE WHEN student_age < 25 THEN 'Under 25' ELSE '25 and Over' END AS age_group, COUNT(*) as count FROM student_level_with_predictions WHERE cohort = 2023 GROUP BY age_group ORDER BY age_group",
+  "sql": "SELECT CASE WHEN \"Student_Age\" < 25 THEN 'Under 25' ELSE '25 and Over' END AS age_group, COUNT(*) as count FROM student_level_with_predictions WHERE \"Cohort\" = 2023 GROUP BY age_group ORDER BY age_group",
   "queryString": ""
 }
 

--- a/codebenders-dashboard/app/api/dashboard/kpis/route.ts
+++ b/codebenders-dashboard/app/api/dashboard/kpis/route.ts
@@ -7,7 +7,7 @@ export async function GET(request: NextRequest) {
 
     const sql = `
       SELECT
-        AVG(retention) * 100 as overall_retention_rate,
+        AVG("Retention") * 100 as overall_retention_rate,
         AVG(retention_probability) * 100 as avg_predicted_retention,
         SUM(CASE WHEN at_risk_alert IN ('HIGH', 'URGENT') THEN 1 ELSE 0 END) as high_critical_risk_count,
         AVG(course_completion_rate) * 100 as avg_course_completion_rate,

--- a/codebenders-dashboard/app/methodology/page.tsx
+++ b/codebenders-dashboard/app/methodology/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import Link from "next/link"
-import { ArrowLeft, BookOpen, Database, FlaskConical, ShieldCheck } from "lucide-react"
+import { ArrowLeft, BookOpen, FlaskConical, GraduationCap, ShieldCheck } from "lucide-react"
 
 export const metadata: Metadata = {
   title: "Readiness Methodology — Bishop State Student Success Dashboard",
@@ -67,8 +67,6 @@ export default function MethodologyPage() {
           </p>
           <div className="flex gap-2 mt-3">
             <Badge variant="outline">Version: rules_v1</Badge>
-            <Badge variant="outline">Script: generate_readiness_scores.py</Badge>
-            <Badge variant="outline">Table: llm_recommendations</Badge>
           </div>
         </div>
 
@@ -112,7 +110,7 @@ export default function MethodologyPage() {
               <CardContent className="text-sm text-muted-foreground">
                 This study found that advisors distrusted and underused opaque machine learning predictions in higher education settings.
                 Transparent, rule-based scoring with human-readable explanations improves advisor adoption and student intervention rates.
-                Every readiness score in this system is fully traceable to its inputs via the <code className="text-xs bg-muted px-1 rounded">input_features</code> column.
+                Every readiness score in this system is fully traceable to its inputs.
               </CardContent>
             </Card>
           </div>
@@ -163,21 +161,21 @@ export default function MethodologyPage() {
                   <thead>
                     <tr className="border-b">
                       <th className="text-left py-1">Component</th>
-                      <th className="text-left py-1">Source Field</th>
+                      <th className="text-left py-1">Input</th>
                       <th className="text-left py-1">Calculation</th>
                     </tr>
                   </thead>
                   <tbody className="text-muted-foreground">
-                    <tr className="border-b"><td className="py-1.5">GPA</td><td className="py-1.5 font-mono text-xs">GPA_Group_Year_1</td><td className="py-1.5">min(gpa / 4.0, 1.0)</td></tr>
-                    <tr className="border-b"><td className="py-1.5">Course completion</td><td className="py-1.5 font-mono text-xs">course_completion_rate</td><td className="py-1.5">direct (0.0–1.0)</td></tr>
-                    <tr className="border-b"><td className="py-1.5">Passing rate</td><td className="py-1.5 font-mono text-xs">passing_rate</td><td className="py-1.5">direct (0.0–1.0)</td></tr>
-                    <tr className="border-b"><td className="py-1.5">Gateway completion</td><td className="py-1.5 font-mono text-xs">CompletedGateway*Year1</td><td className="py-1.5">0.5 + 0.25 per gateway</td></tr>
+                    <tr className="border-b"><td className="py-1.5">GPA</td><td className="py-1.5">GPA Year 1</td><td className="py-1.5">min(gpa / 4.0, 1.0)</td></tr>
+                    <tr className="border-b"><td className="py-1.5">Course completion</td><td className="py-1.5">Completion rate</td><td className="py-1.5">direct (0.0–1.0)</td></tr>
+                    <tr className="border-b"><td className="py-1.5">Passing rate</td><td className="py-1.5">Passing rate</td><td className="py-1.5">direct (0.0–1.0)</td></tr>
+                    <tr className="border-b"><td className="py-1.5">Gateway completion</td><td className="py-1.5">Math &amp; English Year 1</td><td className="py-1.5">0.5 + 0.25 per gateway</td></tr>
                     <tr>
                       <td className="py-1.5 font-medium text-foreground">
                         Credit momentum{" "}
                         <Badge variant="outline" className="ml-1 text-xs">PDP</Badge>
                       </td>
-                      <td className="py-1.5 font-mono text-xs">Credits_Earned_Year_1</td>
+                      <td className="py-1.5">Credits earned Year 1</td>
                       <td className="py-1.5">&ge;12&rarr;1.0, &ge;6&rarr;0.6, &lt;6&rarr;0.3</td>
                     </tr>
                   </tbody>
@@ -198,14 +196,14 @@ export default function MethodologyPage() {
                   <thead>
                     <tr className="border-b">
                       <th className="text-left py-1">Component</th>
-                      <th className="text-left py-1">Source Field</th>
+                      <th className="text-left py-1">Input</th>
                       <th className="text-left py-1">Calculation</th>
                     </tr>
                   </thead>
                   <tbody className="text-muted-foreground">
-                    <tr className="border-b"><td className="py-1.5">Enrollment intensity</td><td className="py-1.5 font-mono text-xs">Enrollment_Intensity_First_Term</td><td className="py-1.5">FT&rarr;1.0, PT&rarr;0.5, unknown&rarr;0.3</td></tr>
-                    <tr className="border-b"><td className="py-1.5">Courses enrolled</td><td className="py-1.5 font-mono text-xs">total_courses_enrolled</td><td className="py-1.5">min(courses / 10, 1.0)</td></tr>
-                    <tr><td className="py-1.5 font-medium text-foreground">Math placement</td><td className="py-1.5 font-mono text-xs">Math_Placement</td><td className="py-1.5">C&rarr;1.0, N&rarr;0.5, R&rarr;0.2</td></tr>
+                    <tr className="border-b"><td className="py-1.5">Enrollment intensity</td><td className="py-1.5">First term status</td><td className="py-1.5">FT&rarr;1.0, PT&rarr;0.5, unknown&rarr;0.3</td></tr>
+                    <tr className="border-b"><td className="py-1.5">Courses enrolled</td><td className="py-1.5">Total courses</td><td className="py-1.5">min(courses / 10, 1.0)</td></tr>
+                    <tr><td className="py-1.5 font-medium text-foreground">Math placement</td><td className="py-1.5">Placement level</td><td className="py-1.5">College&rarr;1.0, Non-placed&rarr;0.5, Remedial&rarr;0.2</td></tr>
                   </tbody>
                 </table>
               </CardContent>
@@ -224,15 +222,148 @@ export default function MethodologyPage() {
                   <thead>
                     <tr className="border-b">
                       <th className="text-left py-1">Component</th>
-                      <th className="text-left py-1">Source Field</th>
+                      <th className="text-left py-1">Input</th>
                       <th className="text-left py-1">Calculation</th>
                     </tr>
                   </thead>
                   <tbody className="text-muted-foreground">
-                    <tr className="border-b"><td className="py-1.5">Retention probability</td><td className="py-1.5 font-mono text-xs">retention_probability</td><td className="py-1.5">direct (Model 1 output)</td></tr>
-                    <tr><td className="py-1.5">At-risk alert</td><td className="py-1.5 font-mono text-xs">at_risk_alert</td><td className="py-1.5">URGENT&rarr;0.1, HIGH&rarr;0.3, MODERATE&rarr;0.6, LOW&rarr;0.9</td></tr>
+                    <tr className="border-b"><td className="py-1.5">Retention probability</td><td className="py-1.5">ML Model 1 output</td><td className="py-1.5">direct (0.0–1.0)</td></tr>
+                    <tr><td className="py-1.5">At-risk alert</td><td className="py-1.5">Risk tier</td><td className="py-1.5">URGENT&rarr;0.1, HIGH&rarr;0.3, MODERATE&rarr;0.6, LOW&rarr;0.9</td></tr>
                   </tbody>
                 </table>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        {/* Worked Examples */}
+        <section className="space-y-4">
+          <div className="flex items-center gap-2">
+            <GraduationCap className="h-5 w-5 text-indigo-500" />
+            <h2 className="text-xl font-semibold">Worked Examples</h2>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            Two hypothetical students illustrate how the same formula produces very different outcomes based on academic momentum and engagement signals.
+          </p>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* High Readiness Example */}
+            <Card className="border-green-200">
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-base">Maria T.</CardTitle>
+                  <Badge className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100">High Readiness</Badge>
+                </div>
+                <CardDescription>First-generation student, part-time enrollment</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm">
+                {/* Inputs */}
+                <div>
+                  <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground mb-1.5">Inputs</p>
+                  <table className="w-full text-xs">
+                    <tbody className="text-muted-foreground">
+                      <tr className="border-b"><td className="py-1">GPA (Year 1)</td><td className="py-1 text-right font-mono">3.2</td></tr>
+                      <tr className="border-b"><td className="py-1">Course completion</td><td className="py-1 text-right font-mono">0.83</td></tr>
+                      <tr className="border-b"><td className="py-1">Passing rate</td><td className="py-1 text-right font-mono">0.78</td></tr>
+                      <tr className="border-b"><td className="py-1">Gateways completed</td><td className="py-1 text-right font-mono">1 of 2 (Math)</td></tr>
+                      <tr className="border-b"><td className="py-1">Credits earned</td><td className="py-1 text-right font-mono">9</td></tr>
+                      <tr className="border-b"><td className="py-1">Enrollment intensity</td><td className="py-1 text-right font-mono">Part-time</td></tr>
+                      <tr className="border-b"><td className="py-1">Courses enrolled</td><td className="py-1 text-right font-mono">5</td></tr>
+                      <tr className="border-b"><td className="py-1">Math placement</td><td className="py-1 text-right font-mono">College-level</td></tr>
+                      <tr className="border-b"><td className="py-1">Retention probability</td><td className="py-1 text-right font-mono">0.72</td></tr>
+                      <tr><td className="py-1">At-risk alert</td><td className="py-1 text-right font-mono">MODERATE</td></tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Sub-scores */}
+                <div className="space-y-2">
+                  <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground">Calculation</p>
+                  <div className="bg-muted rounded-md p-3 space-y-2 font-mono text-xs">
+                    <div>
+                      <p className="text-muted-foreground">Academic (avg of 5)</p>
+                      <p>0.80 + 0.83 + 0.78 + 0.75 + 0.60</p>
+                      <p className="font-semibold">= 0.752 &times; 0.40 = 0.301</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">Engagement (avg of 3)</p>
+                      <p>0.50 + 0.50 + 1.00</p>
+                      <p className="font-semibold">= 0.667 &times; 0.30 = 0.200</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">ML Risk (avg of 2)</p>
+                      <p>0.72 + 0.60</p>
+                      <p className="font-semibold">= 0.660 &times; 0.30 = 0.198</p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Final score */}
+                <div className="bg-green-50 border border-green-200 rounded-md p-3 text-center">
+                  <p className="text-xs text-green-700 mb-0.5">0.301 + 0.200 + 0.198</p>
+                  <p className="text-2xl font-bold text-green-700">0.699</p>
+                  <p className="text-sm font-medium text-green-600">High Readiness</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Low Readiness Example */}
+            <Card className="border-red-200">
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-base">Jordan M.</CardTitle>
+                  <Badge className="bg-red-100 text-red-800 border-red-200 hover:bg-red-100">Low Readiness</Badge>
+                </div>
+                <CardDescription>Remedial-track student, part-time enrollment</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm">
+                {/* Inputs */}
+                <div>
+                  <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground mb-1.5">Inputs</p>
+                  <table className="w-full text-xs">
+                    <tbody className="text-muted-foreground">
+                      <tr className="border-b"><td className="py-1">GPA (Year 1)</td><td className="py-1 text-right font-mono">1.8</td></tr>
+                      <tr className="border-b"><td className="py-1">Course completion</td><td className="py-1 text-right font-mono">0.55</td></tr>
+                      <tr className="border-b"><td className="py-1">Passing rate</td><td className="py-1 text-right font-mono">0.50</td></tr>
+                      <tr className="border-b"><td className="py-1">Gateways completed</td><td className="py-1 text-right font-mono">0 of 2</td></tr>
+                      <tr className="border-b"><td className="py-1">Credits earned</td><td className="py-1 text-right font-mono">4</td></tr>
+                      <tr className="border-b"><td className="py-1">Enrollment intensity</td><td className="py-1 text-right font-mono">Part-time</td></tr>
+                      <tr className="border-b"><td className="py-1">Courses enrolled</td><td className="py-1 text-right font-mono">3</td></tr>
+                      <tr className="border-b"><td className="py-1">Math placement</td><td className="py-1 text-right font-mono">Remedial</td></tr>
+                      <tr className="border-b"><td className="py-1">Retention probability</td><td className="py-1 text-right font-mono">0.38</td></tr>
+                      <tr><td className="py-1">At-risk alert</td><td className="py-1 text-right font-mono">HIGH</td></tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Sub-scores */}
+                <div className="space-y-2">
+                  <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground">Calculation</p>
+                  <div className="bg-muted rounded-md p-3 space-y-2 font-mono text-xs">
+                    <div>
+                      <p className="text-muted-foreground">Academic (avg of 5)</p>
+                      <p>0.45 + 0.55 + 0.50 + 0.50 + 0.30</p>
+                      <p className="font-semibold">= 0.460 &times; 0.40 = 0.184</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">Engagement (avg of 3)</p>
+                      <p>0.50 + 0.30 + 0.20</p>
+                      <p className="font-semibold">= 0.333 &times; 0.30 = 0.100</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">ML Risk (avg of 2)</p>
+                      <p>0.38 + 0.30</p>
+                      <p className="font-semibold">= 0.340 &times; 0.30 = 0.102</p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Final score */}
+                <div className="bg-red-50 border border-red-200 rounded-md p-3 text-center">
+                  <p className="text-xs text-red-700 mb-0.5">0.184 + 0.100 + 0.102</p>
+                  <p className="text-2xl font-bold text-red-700">0.386</p>
+                  <p className="text-sm font-medium text-red-600">Low Readiness</p>
+                </div>
               </CardContent>
             </Card>
           </div>
@@ -247,32 +378,12 @@ export default function MethodologyPage() {
           <Card>
             <CardContent className="pt-6 text-sm text-muted-foreground space-y-2">
               <p>
-                The <code className="text-xs bg-muted px-1 rounded">input_features</code> column stores a stripped profile with <strong>no PII</strong>: Student_GUID and zip code are excluded before storage.
+                Readiness scores are computed from a stripped profile with <strong>no PII</strong>: student identifiers and zip code are excluded before processing.
                 Only aggregate behavioral metrics (GPA group, completion rate, placement level, enrollment type) are retained.
               </p>
               <p>
-                When LLM narrative enrichment is enabled, only the FERPA-safe profile is transmitted to the LLM provider — never the Student_GUID, name, date of birth, or address.
+                When LLM narrative enrichment is enabled, only the FERPA-safe profile is transmitted to the LLM provider — never the student identifier, name, date of birth, or address.
                 This satisfies FERPA §99.31(a)(1) for legitimate educational interest use.
-              </p>
-            </CardContent>
-          </Card>
-        </section>
-
-        {/* Data Source */}
-        <section className="space-y-4">
-          <div className="flex items-center gap-2">
-            <Database className="h-5 w-5 text-orange-500" />
-            <h2 className="text-xl font-semibold">Data Source</h2>
-          </div>
-          <Card>
-            <CardContent className="pt-6 text-sm space-y-1">
-              <p><strong>Input table:</strong> <code className="text-xs bg-muted px-1 rounded">student_level_with_predictions</code> (~4,000 students)</p>
-              <p><strong>Output table:</strong> <code className="text-xs bg-muted px-1 rounded">llm_recommendations</code></p>
-              <p><strong>Scoring script:</strong> <code className="text-xs bg-muted px-1 rounded">ai_model/generate_readiness_scores.py</code></p>
-              <p><strong>Re-run command:</strong> <code className="text-xs bg-muted px-1 rounded">venv/bin/python ai_model/generate_readiness_scores.py</code></p>
-              <p className="text-muted-foreground mt-2">
-                Re-running the script upserts scores — no duplicates are created. Each run is logged in{" "}
-                <code className="text-xs bg-muted px-1 rounded">readiness_generation_runs</code>.
               </p>
             </CardContent>
           </Card>

--- a/codebenders-dashboard/components/retention-risk-chart.tsx
+++ b/codebenders-dashboard/components/retention-risk-chart.tsx
@@ -64,7 +64,7 @@ export function RetentionRiskChart({ data, loading = false, info }: RetentionRis
 
   const chartData = data.map(item => ({
     category: item.category,
-    count: item.count,
+    count: Number(item.count),
     percentage: item.percentage,
   }))
 

--- a/codebenders-dashboard/components/risk-alert-chart.tsx
+++ b/codebenders-dashboard/components/risk-alert-chart.tsx
@@ -84,7 +84,7 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
 
   const chartData = data.map(item => ({
     name: item.category,
-    value: item.count,
+    value: Number(item.count),
     percentage: item.percentage,
   }))
 


### PR DESCRIPTION
## Summary

- Remove internal implementation badges (`Script: generate_readiness_scores.py`, `Table: llm_recommendations`) from the page header
- Remove the "Data Source" section (table names, script path, re-run command — not meaningful to advisors/admins)
- Clean up sub-score tables: replace raw DB column names with plain English labels
- Add "Worked Examples" section with two side-by-side students showing the full score calculation

## Examples added

| Student | Profile | Final Score | Tier |
|---------|---------|-------------|------|
| Maria T. | First-gen, part-time, 1 gateway done, college-level math | 0.699 | High Readiness |
| Jordan M. | Remedial-track, part-time, 0 gateways, 4 credits earned | 0.386 | Low Readiness |

Each example includes an inputs table, step-by-step sub-score math (academic / engagement / ML), and a color-coded final score callout.

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [ ] Visit `/methodology` and confirm Data Source section and impl badges are gone
- [ ] Confirm both worked examples render with correct numbers and color coding
- [ ] Confirm page is responsive on mobile widths

Closes #59