### PR TITLE
feat: SQL Query Interface UX — result table, chart layout, tooltips, prompt history

### DIFF
--- a/codebenders-dashboard/.gitignore
+++ b/codebenders-dashboard/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 # Typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Audit logs
+logs/

--- a/codebenders-dashboard/app/api/analyze/route.ts
+++ b/codebenders-dashboard/app/api/analyze/route.ts
@@ -18,50 +18,55 @@ const queryPlanSchema = z.object({
 })
 
 // Database schema configuration
+// IMPORTANT: Column names listed here are the EXACT case-sensitive names in PostgreSQL.
+// Mixed-case columns (e.g. "Cohort", "Retention") must be double-quoted in generated SQL.
+// All-lowercase columns (e.g. retention_probability) do not require quoting.
 const SCHEMA_INFO = {
   bscc: {
     database: "postgres",
     mainTable: "student_level_with_predictions",
     description: "Bishop State Community College student cohort data with retention, persistence, and completion metrics",
     columns: {
-      // Key dimensions
-      cohort: "Cohort year (numeric: 2019, 2020, etc.)",
-      cohort_term: "Term of cohort entry (Fall, Spring, Summer)",
-      student_guid: "Unique student identifier",
-      institution_id: "Institution identifier (102030 for Bishop State)",
+      // Key dimensions — MIXED CASE: must be double-quoted in SQL
+      Cohort: "Cohort year (numeric: 2019, 2020, etc.) — write as \"Cohort\"",
+      Cohort_Term: "Term of cohort entry (Fall, Spring, Summer) — write as \"Cohort_Term\"",
+      Student_GUID: "Unique student identifier — write as \"Student_GUID\"",
+      Institution_ID: "Institution identifier (102030 for Bishop State) — write as \"Institution_ID\"",
 
-      // Demographics
-      gender: "Student gender",
-      race: "Student race/ethnicity",
-      student_age: "Age of student",
-      first_gen: "First generation status",
+      // Demographics — MIXED CASE: must be double-quoted in SQL
+      Gender: "Student gender — write as \"Gender\"",
+      Race: "Student race/ethnicity — write as \"Race\"",
+      Student_Age: "Age of student (integer) — write as \"Student_Age\"",
+      First_Gen: "First generation status — write as \"First_Gen\"",
 
-      // Academic info
-      enrollment_type: "Type of enrollment",
-      enrollment_intensity_first_term: "Enrollment intensity in first term (Full-Time, Part-Time)",
-      program_of_study_year_1: "Program of study in year 1 (CIP code)",
-      credential_type_sought_year_1: "Credential type being pursued",
+      // Academic info — MIXED CASE: must be double-quoted in SQL
+      Enrollment_Type: "Type of enrollment — write as \"Enrollment_Type\"",
+      Enrollment_Intensity_First_Term: "Enrollment intensity in first term (Full-Time, Part-Time) — write as \"Enrollment_Intensity_First_Term\"",
+      Program_of_Study_Year_1: "Program of study in year 1 (CIP code) — write as \"Program_of_Study_Year_1\"",
+      Credential_Type_Sought_Year_1: "Credential type being pursued — write as \"Credential_Type_Sought_Year_1\"",
+      Math_Placement: "Math placement level (C=college-level, R=remedial, N=none) — write as \"Math_Placement\"",
 
-      // Performance metrics
-      retention: "Retention indicator (0 or 1)",
-      persistence: "Persistence indicator (0 or 1)",
-      gpa_group_year_1: "GPA in year 1",
-      gpa_group_term_1: "GPA in term 1",
+      // Performance metrics — MIXED CASE: must be double-quoted in SQL
+      Retention: "Retention indicator (0 or 1) — write as \"Retention\"",
+      Persistence: "Persistence indicator (0 or 1) — write as \"Persistence\"",
+      GPA_Group_Year_1: "GPA in year 1 — write as \"GPA_Group_Year_1\"",
+      GPA_Group_Term_1: "GPA in term 1 — write as \"GPA_Group_Term_1\"",
 
-      // Credits
-      number_of_credits_attempted_year_1: "Credits attempted in year 1",
-      number_of_credits_earned_year_1: "Credits earned in year 1",
-      number_of_credits_attempted_year_2: "Credits attempted in year 2",
-      number_of_credits_earned_year_2: "Credits earned in year 2",
+      // Credits — MIXED CASE: must be double-quoted in SQL
+      Number_of_Credits_Attempted_Year_1: "Credits attempted in year 1 — write as \"Number_of_Credits_Attempted_Year_1\"",
+      Number_of_Credits_Earned_Year_1: "Credits earned in year 1 — write as \"Number_of_Credits_Earned_Year_1\"",
+      Number_of_Credits_Attempted_Year_2: "Credits attempted in year 2 — write as \"Number_of_Credits_Attempted_Year_2\"",
+      Number_of_Credits_Earned_Year_2: "Credits earned in year 2 — write as \"Number_of_Credits_Earned_Year_2\"",
 
-      // Completion metrics
-      time_to_credential: "Time to any credential",
+      // Completion metrics — MIXED CASE: must be double-quoted in SQL
+      Time_to_Credential: "Time to any credential — write as \"Time_to_Credential\"",
 
-      // ML predictions
+      // ML predictions — all lowercase: no quoting needed
       retention_probability: "Predicted probability of retention (0-1)",
       retention_risk_category: "Risk category (Low Risk, Moderate Risk, High Risk, Critical Risk)",
       at_risk_alert: "Early warning alert level (LOW, MODERATE, HIGH, URGENT)",
-      predicted_gpa: "ML-predicted GPA",
+      course_completion_rate: "Course completion rate (0-1)",
+      passing_rate: "Course passing rate (0-1)",
     },
   },
   akron: {
@@ -107,10 +112,14 @@ KEY COLUMNS:
 ${Object.entries(schemaInfo.columns).map(([col, desc]) => `- ${col}: ${desc}`).join("\n")}
 
 CRITICAL SCHEMA NOTES:
-- cohort: NUMERIC year only (e.g., 2019, 2020) — NOT a string like "2024-Fall"
-- cohort_term: Term name (e.g., "Fall", "Spring", "Summer")
-- To filter by "Fall 2023", use: WHERE cohort = 2023 AND cohort_term = 'Fall'
-- student_age: INTEGER field — use direct numeric comparisons (e.g., student_age >= 25)
+- Column names with uppercase letters MUST be double-quoted in PostgreSQL SQL or the query will fail.
+  CORRECT:   WHERE "Cohort" = 2023 AND "Cohort_Term" = 'Fall'
+  INCORRECT: WHERE cohort = 2023 AND cohort_term = 'Fall'
+- "Cohort": NUMERIC year only (e.g., 2019, 2020) — NOT a string like "2024-Fall"
+- "Cohort_Term": Term name (e.g., "Fall", "Spring", "Summer")
+- To filter by "Fall 2023", use: WHERE "Cohort" = 2023 AND "Cohort_Term" = 'Fall'
+- "Student_Age": INTEGER field — use direct numeric comparisons (e.g., "Student_Age" >= 25)
+- Lowercase ML columns (retention_probability, at_risk_alert, etc.) do NOT need quoting.
 - Use standard PostgreSQL syntax — no backtick quoting, no cross-database references
 
 IMPORTANT QUERY INTERPRETATION RULES:
@@ -118,28 +127,28 @@ IMPORTANT QUERY INTERPRETATION RULES:
 1. METRIC SELECTION:
    - ONLY include a metric if the user explicitly asks for retention, persistence, GPA, credits, etc.
    - If user asks to "segment", "compare", "show", "count", or "list" students → use COUNT(*) and NO specific metric
-   - "retention" → AVG(retention) as retention_rate
-   - "persistence" or "completion" → AVG(persistence) as completion_rate
-   - "GPA" → AVG(gpa_group_year_1) as gpa
-   - "credits" → AVG(number_of_credits_earned_year_1) as credits_earned
+   - "retention" → AVG("Retention") as retention_rate
+   - "persistence" or "completion" → AVG("Persistence") as completion_rate
+   - "GPA" → AVG("GPA_Group_Year_1") as gpa
+   - "credits" → AVG("Number_of_Credits_Earned_Year_1") as credits_earned
    - Otherwise → COUNT(*) as count
 
 2. GROUPING & SEGMENTATION:
    - "segment by X" or "compare X" → GROUP BY X column
    - "by age", "age groups", "segment by age" → Use CASE statement to create age groups:
      CASE
-       WHEN student_age < 25 THEN 'Under 25'
-       WHEN student_age >= 25 THEN '25 and Over'
+       WHEN "Student_Age" < 25 THEN 'Under 25'
+       WHEN "Student_Age" >= 25 THEN '25 and Over'
      END AS age_group
-   - "by gender" → GROUP BY gender
-   - "by race" → GROUP BY race
-   - "by cohort" → GROUP BY cohort
-   - "by term" → GROUP BY cohort_term
+   - "by gender" → GROUP BY "Gender"
+   - "by race" → GROUP BY "Race"
+   - "by cohort" → GROUP BY "Cohort"
+   - "by term" → GROUP BY "Cohort_Term"
 
 3. FILTERS:
-   - "2023 cohort" → WHERE cohort = 2023
-   - "Fall 2023" or "2023 Fall" → WHERE cohort = 2023 AND cohort_term = 'Fall'
-   - Age filters: use numeric comparisons directly (e.g., student_age >= 25)
+   - "2023 cohort" → WHERE "Cohort" = 2023
+   - "Fall 2023" or "2023 Fall" → WHERE "Cohort" = 2023 AND "Cohort_Term" = 'Fall'
+   - Age filters: use numeric comparisons directly (e.g., "Student_Age" >= 25)
 
 4. VISUALIZATION:
    - Comparing groups (age, gender, race) → "bar"
@@ -163,7 +172,7 @@ Generate a query plan with:
 EXAMPLE for "segment students over 25 and under 25 in 2023 cohort":
 {
   "vizType": "bar",
-  "sql": "SELECT CASE WHEN student_age < 25 THEN 'Under 25' ELSE '25 and Over' END AS age_group, COUNT(*) as count FROM student_level_with_predictions WHERE cohort = 2023 GROUP BY age_group ORDER BY age_group",
+  "sql": "SELECT CASE WHEN \"Student_Age\" < 25 THEN 'Under 25' ELSE '25 and Over' END AS age_group, COUNT(*) as count FROM student_level_with_predictions WHERE \"Cohort\" = 2023 GROUP BY age_group ORDER BY age_group",
   "queryString": ""
 }
 

--- a/codebenders-dashboard/app/api/dashboard/kpis/route.ts
+++ b/codebenders-dashboard/app/api/dashboard/kpis/route.ts
@@ -7,7 +7,7 @@ export async function GET(request: NextRequest) {
 
     const sql = `
       SELECT
-        AVG(retention) * 100 as overall_retention_rate,
+        AVG("Retention") * 100 as overall_retention_rate,
         AVG(retention_probability) * 100 as avg_predicted_retention,
         SUM(CASE WHEN at_risk_alert IN ('HIGH', 'URGENT') THEN 1 ELSE 0 END) as high_critical_risk_count,
         AVG(course_completion_rate) * 100 as avg_course_completion_rate,

--- a/codebenders-dashboard/app/api/query-history/route.ts
+++ b/codebenders-dashboard/app/api/query-history/route.ts
@@ -1,0 +1,60 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { mkdir, appendFile } from "fs/promises"
+import path from "path"
+
+const LOGS_DIR = path.join(process.cwd(), "logs")
+const LOG_FILE = path.join(LOGS_DIR, "query-history.jsonl")
+
+interface QueryHistoryEntry {
+  prompt: string
+  institution: string
+  vizType: string
+  rowCount: number
+  timestamp: string
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown
+
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const entry = body as Record<string, unknown>
+
+  // Validate required fields
+  if (
+    typeof entry.prompt !== "string" ||
+    typeof entry.institution !== "string" ||
+    typeof entry.vizType !== "string" ||
+    typeof entry.rowCount !== "number" ||
+    typeof entry.timestamp !== "string"
+  ) {
+    return NextResponse.json(
+      { error: "Missing or invalid required fields: prompt, institution, vizType, rowCount, timestamp" },
+      { status: 400 }
+    )
+  }
+
+  const record: QueryHistoryEntry = {
+    prompt: entry.prompt,
+    institution: entry.institution,
+    vizType: entry.vizType,
+    rowCount: entry.rowCount,
+    timestamp: entry.timestamp,
+  }
+
+  try {
+    await mkdir(LOGS_DIR, { recursive: true })
+    await appendFile(LOG_FILE, JSON.stringify(record) + "\n", "utf8")
+    return NextResponse.json({ ok: true }, { status: 200 })
+  } catch (error) {
+    console.error("query-history write error:", error)
+    return NextResponse.json(
+      { error: "Failed to write log entry" },
+      { status: 500 }
+    )
+  }
+}

--- a/codebenders-dashboard/app/query/page.tsx
+++ b/codebenders-dashboard/app/query/page.tsx
@@ -9,9 +9,10 @@ import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
 import { AnalysisResult } from "@/components/analysis-result"
 import { QueryPlanPanel } from "@/components/query-plan-panel"
+import { QueryHistoryPanel } from "@/components/query-history-panel"
 import { analyzePrompt } from "@/lib/prompt-analyzer"
 import { executeQuery } from "@/lib/query-executor"
-import type { QueryPlan, QueryResult } from "@/lib/types"
+import type { QueryPlan, QueryResult, HistoryEntry } from "@/lib/types"
 import Link from "next/link"
 import { ArrowLeft } from "lucide-react"
 
@@ -29,10 +30,25 @@ export default function QueryPage() {
   const [queryPlan, setQueryPlan] = useState<QueryPlan | null>(null)
   const [queryResult, setQueryResult] = useState<QueryResult | null>(null)
   const [useDirectDB, setUseDirectDB] = useState(true)
+  const [history, setHistory] = useState<HistoryEntry[]>(() => {
+    // Read from localStorage on mount (client-only)
+    if (typeof window === "undefined") return []
+    try {
+      return JSON.parse(localStorage.getItem("bishop_query_history") || "[]")
+    } catch {
+      return []
+    }
+  })
 
-  const handleAnalyze = async () => {
-    console.log("handleAnalyze", prompt, institution)
-    if (!prompt.trim()) return
+  const handleAnalyze = async (
+    overridePrompt?: string,
+    overrideInstitution?: string,
+  ) => {
+    const activePrompt = overridePrompt ?? prompt
+    const activeInstitution = overrideInstitution ?? institution
+
+    console.log("handleAnalyze", activePrompt, activeInstitution)
+    if (!activePrompt.trim()) return
 
     setIsAnalyzing(true)
     try {
@@ -45,11 +61,11 @@ export default function QueryPage() {
         const response = await fetch("/api/analyze", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ prompt, institution }),
+          body: JSON.stringify({ prompt: activePrompt, institution: activeInstitution }),
         })
 
         console.log("response status:", response.status)
-        
+
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}))
           console.error("response error", response.status, errorData)
@@ -59,20 +75,54 @@ export default function QueryPage() {
         plan = await response.json()
         console.log("plan received:", plan)
       } else {
-        plan = analyzePrompt(prompt, institution)
+        plan = analyzePrompt(activePrompt, activeInstitution)
       }
 
       setQueryPlan(plan)
       console.log("executing query with plan:", plan)
-      const result = await executeQuery(plan, institution, useDirectDB)
+      const result = await executeQuery(plan, activeInstitution, useDirectDB)
       console.log("query result:", result)
       setQueryResult(result)
+
+      // Persist history entry
+      const entry: HistoryEntry = {
+        id: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+        institution: activeInstitution,
+        prompt: activePrompt,
+        rowCount: result.rowCount,
+        vizType: plan.vizType,
+      }
+      // Prepend and cap at 50 entries
+      setHistory(prev => {
+        const updated = [entry, ...prev].slice(0, 50)
+        localStorage.setItem("bishop_query_history", JSON.stringify(updated))
+        return updated
+      })
+
+      // Fire-and-forget audit log — don't await or block on failure
+      fetch("/api/query-history", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(entry),
+      }).catch(() => {/* ignore audit failures */})
     } catch (error) {
       console.error("Error analyzing prompt:", error)
       alert("Error: " + (error instanceof Error ? error.message : String(error)))
     } finally {
       setIsAnalyzing(false)
     }
+  }
+
+  const handleRerun = (entry: HistoryEntry) => {
+    setInstitution(entry.institution)
+    setPrompt(entry.prompt)
+    handleAnalyze(entry.prompt, entry.institution)
+  }
+
+  const handleClear = () => {
+    setHistory([])
+    localStorage.removeItem("bishop_query_history")
   }
 
   return (
@@ -136,13 +186,21 @@ export default function QueryPage() {
               </div>
 
               <div className="flex items-end">
-                <Button onClick={handleAnalyze} disabled={isAnalyzing || !prompt.trim()} className="w-full md:w-auto">
+                <Button onClick={() => handleAnalyze()} disabled={isAnalyzing || !prompt.trim()} className="w-full md:w-auto">
                   {isAnalyzing ? "Analyzing..." : "Analyze"}
                 </Button>
               </div>
             </div>
           </CardContent>
         </Card>
+
+        {history.length > 0 && (
+          <QueryHistoryPanel
+            entries={history}
+            onRerun={handleRerun}
+            onClear={handleClear}
+          />
+        )}
 
         {queryResult && queryPlan && (
           <div className="grid gap-6 lg:grid-cols-[1fr_400px]">
@@ -165,4 +223,3 @@ export default function QueryPage() {
     </div>
   )
 }
-

--- a/codebenders-dashboard/components/analysis-result.tsx
+++ b/codebenders-dashboard/components/analysis-result.tsx
@@ -31,10 +31,37 @@ const CHART_COLORS = [
 ]
 
 export function AnalysisResult({ result, plan }: AnalysisResultProps) {
+  const renderDataTable = () => {
+    if (!result.data || result.data.length === 0) return null
+    const columns = Object.keys(result.data[0] || {})
+    return (
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {columns.map((col) => (
+              <TableHead key={col} className="capitalize">
+                {col.replace(/_/g, " ")}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {result.data.map((row, idx) => (
+            <TableRow key={idx}>
+              {columns.map((col) => (
+                <TableCell key={col}>{typeof row[col] === "number" ? row[col].toFixed(2) : row[col]}</TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    )
+  }
+
   const renderVisualization = () => {
     if (!result.data || result.data.length === 0) {
       return (
-        <div className="flex items-center justify-center h-[400px]">
+        <div className="flex items-center justify-center h-48">
           <div className="text-center space-y-2">
             <p className="text-muted-foreground">No data available</p>
           </div>
@@ -50,93 +77,102 @@ export function AnalysisResult({ result, plan }: AnalysisResultProps) {
     switch (plan.vizType) {
       case "line":
         return (
-          <ResponsiveContainer width="100%" height={400}>
-            <LineChart data={result.data}>
-              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-              <XAxis dataKey={groupByKey} stroke="hsl(var(--muted-foreground))" />
-              <YAxis stroke="hsl(var(--muted-foreground))" />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: "hsl(var(--popover))",
-                  border: "1px solid hsl(var(--border))",
-                  borderRadius: "var(--radius)",
-                }}
-              />
-              <Legend />
-              <Line 
-                type="monotone" 
-                dataKey={metricKey}
-                stroke={CHART_COLORS[0]}
-                strokeWidth={2}
-                dot={{ fill: CHART_COLORS[0] }}
-                name={metricKey.replace(/_/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())}
-              />
-            </LineChart>
-          </ResponsiveContainer>
+          <div className="overflow-visible">
+            <ResponsiveContainer width="100%" aspect={16 / 7}>
+              <LineChart data={result.data}>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey={groupByKey} stroke="hsl(var(--muted-foreground))" />
+                <YAxis stroke="hsl(var(--muted-foreground))" />
+                <Tooltip
+                  wrapperStyle={{ zIndex: 10, overflow: 'visible' as const }}
+                  contentStyle={{
+                    backgroundColor: "hsl(var(--popover))",
+                    border: "1px solid hsl(var(--border))",
+                    borderRadius: "var(--radius)",
+                  }}
+                />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey={metricKey}
+                  stroke={CHART_COLORS[0]}
+                  strokeWidth={2}
+                  dot={{ fill: CHART_COLORS[0] }}
+                  name={metricKey.replace(/_/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
         )
 
       case "bar":
         return (
-          <ResponsiveContainer width="100%" height={400}>
-            <BarChart data={result.data}>
-              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-              <XAxis dataKey={groupByKey} stroke="hsl(var(--muted-foreground))" />
-              <YAxis stroke="hsl(var(--muted-foreground))" />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: "hsl(var(--popover))",
-                  border: "1px solid hsl(var(--border))",
-                  borderRadius: "var(--radius)",
-                }}
-              />
-              <Legend />
-              <Bar 
-                dataKey={metricKey} 
-                fill={CHART_COLORS[0]} 
-                radius={[4, 4, 0, 0]}
-                name={metricKey.replace(/_/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())}
-              />
-            </BarChart>
-          </ResponsiveContainer>
+          <div className="overflow-visible">
+            <ResponsiveContainer width="100%" aspect={16 / 7}>
+              <BarChart data={result.data}>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey={groupByKey} stroke="hsl(var(--muted-foreground))" />
+                <YAxis stroke="hsl(var(--muted-foreground))" />
+                <Tooltip
+                  wrapperStyle={{ zIndex: 10, overflow: 'visible' as const }}
+                  contentStyle={{
+                    backgroundColor: "hsl(var(--popover))",
+                    border: "1px solid hsl(var(--border))",
+                    borderRadius: "var(--radius)",
+                  }}
+                />
+                <Legend />
+                <Bar
+                  dataKey={metricKey}
+                  fill={CHART_COLORS[0]}
+                  radius={[4, 4, 0, 0]}
+                  name={metricKey.replace(/_/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         )
 
       case "pie":
         return (
-          <ResponsiveContainer width="100%" height={400}>
-            <PieChart>
-              <Pie
-                data={result.data}
-                dataKey={metricKey}
-                nameKey={groupByKey}
-                cx="50%"
-                cy="50%"
-                outerRadius={120}
-                label
-              >
-                {result.data.map((_, index) => (
-                  <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
-                ))}
-              </Pie>
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: "hsl(var(--popover))",
-                  border: "1px solid hsl(var(--border))",
-                  borderRadius: "var(--radius)",
-                }}
-              />
-              <Legend 
-                verticalAlign="bottom" 
-                height={36}
-                formatter={(value) => value.replace(/_/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+          <div className="overflow-visible">
+            <ResponsiveContainer width="100%" aspect={4 / 3}>
+              <PieChart>
+                <Pie
+                  data={result.data}
+                  dataKey={metricKey}
+                  nameKey={groupByKey}
+                  cx="50%"
+                  cy="50%"
+                  outerRadius="40%"
+                  label
+                >
+                  {result.data.map((_, index) => (
+                    <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  wrapperStyle={{ zIndex: 10, overflow: 'visible' as const }}
+                  contentStyle={{
+                    backgroundColor: "hsl(var(--popover))",
+                    border: "1px solid hsl(var(--border))",
+                    borderRadius: "var(--radius)",
+                  }}
+                />
+                <Legend
+                  verticalAlign="bottom"
+                  height={36}
+                  formatter={(value) => value.replace(/_/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
         )
 
       case "kpi":
-        const kpiValue = result.data[0]?.[metricKey] || 0
+        const kpiValue = result.data[0]?.[metricKey] ?? 0
         return (
-          <div className="flex items-center justify-center h-[400px]">
+          <div className="flex items-center justify-center h-48">
             <div className="text-center space-y-4">
               <div className="text-6xl font-bold text-foreground">
                 {typeof kpiValue === "number" ? kpiValue.toFixed(1) : kpiValue}
@@ -148,29 +184,9 @@ export function AnalysisResult({ result, plan }: AnalysisResultProps) {
         )
 
       case "table":
-        const columns = Object.keys(result.data[0] || {})
         return (
           <div className="rounded-md border border-border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  {columns.map((col) => (
-                    <TableHead key={col} className="capitalize">
-                      {col.replace(/_/g, " ")}
-                    </TableHead>
-                  ))}
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {result.data.map((row, idx) => (
-                  <TableRow key={idx}>
-                    {columns.map((col) => (
-                      <TableCell key={col}>{typeof row[col] === "number" ? row[col].toFixed(2) : row[col]}</TableCell>
-                    ))}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+            {renderDataTable()}
           </div>
         )
 
@@ -187,7 +203,17 @@ export function AnalysisResult({ result, plan }: AnalysisResultProps) {
           {result.rowCount} {result.rowCount === 1 ? "record" : "records"} found
         </CardDescription>
       </CardHeader>
-      <CardContent>{renderVisualization()}</CardContent>
+      <CardContent>
+        {renderVisualization()}
+        {plan.vizType !== "table" && result.data && result.data.length > 0 && (
+          <div className="mt-4">
+            <p className="text-xs text-muted-foreground mb-2">Raw data ({result.rowCount} rows)</p>
+            <div className="max-h-64 overflow-y-auto rounded-md border border-border">
+              {renderDataTable()}
+            </div>
+          </div>
+        )}
+      </CardContent>
     </Card>
   )
 }

--- a/codebenders-dashboard/components/analysis-result.tsx
+++ b/codebenders-dashboard/components/analysis-result.tsx
@@ -117,6 +117,7 @@ export function AnalysisResult({ result, plan }: AnalysisResultProps) {
                 <XAxis dataKey={groupByKey} stroke="var(--muted-foreground)" />
                 <YAxis stroke="var(--muted-foreground)" />
                 <Tooltip
+                  cursor={false}
                   wrapperStyle={{ zIndex: 10, overflow: 'visible' as const }}
                   contentStyle={TOOLTIP_STYLE}
                 />

--- a/codebenders-dashboard/components/analysis-result.tsx
+++ b/codebenders-dashboard/components/analysis-result.tsx
@@ -23,12 +23,19 @@ interface AnalysisResultProps {
 }
 
 const CHART_COLORS = [
-  "hsl(var(--chart-1))",
-  "hsl(var(--chart-2))",
-  "hsl(var(--chart-3))",
-  "hsl(var(--chart-4))",
-  "hsl(var(--chart-5))",
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
 ]
+
+const TOOLTIP_STYLE = {
+  backgroundColor: "var(--popover)",
+  border: "1px solid var(--border)",
+  borderRadius: "var(--radius)",
+  color: "var(--popover-foreground)",
+}
 
 export function AnalysisResult({ result, plan }: AnalysisResultProps) {
   const renderDataTable = () => {
@@ -80,16 +87,12 @@ export function AnalysisResult({ result, plan }: AnalysisResultProps) {
           <div className="overflow-visible">
             <ResponsiveContainer width="100%" aspect={16 / 7}>
               <LineChart data={result.data}>
-                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                <XAxis dataKey={groupByKey} stroke="hsl(var(--muted-foreground))" />
-                <YAxis stroke="hsl(var(--muted-foreground))" />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                <XAxis dataKey={groupByKey} stroke="var(--muted-foreground)" />
+                <YAxis stroke="var(--muted-foreground)" />
                 <Tooltip
                   wrapperStyle={{ zIndex: 10, overflow: 'visible' as const }}
-                  contentStyle={{
-                    backgroundColor: "hsl(var(--popover))",
-                    border: "1px solid hsl(var(--border))",
-                    borderRadius: "var(--radius)",
-                  }}
+                  contentStyle={TOOLTIP_STYLE}
                 />
                 <Legend />
                 <Line
@@ -110,22 +113,19 @@ export function AnalysisResult({ result, plan }: AnalysisResultProps) {
           <div className="overflow-visible">
             <ResponsiveContainer width="100%" aspect={16 / 7}>
               <BarChart data={result.data}>
-                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                <XAxis dataKey={groupByKey} stroke="hsl(var(--muted-foreground))" />
-                <YAxis stroke="hsl(var(--muted-foreground))" />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                <XAxis dataKey={groupByKey} stroke="var(--muted-foreground)" />
+                <YAxis stroke="var(--muted-foreground)" />
                 <Tooltip
                   wrapperStyle={{ zIndex: 10, overflow: 'visible' as const }}
-                  contentStyle={{
-                    backgroundColor: "hsl(var(--popover))",
-                    border: "1px solid hsl(var(--border))",
-                    borderRadius: "var(--radius)",
-                  }}
+                  contentStyle={TOOLTIP_STYLE}
                 />
                 <Legend />
                 <Bar
                   dataKey={metricKey}
                   fill={CHART_COLORS[0]}
                   radius={[4, 4, 0, 0]}
+                  maxBarSize={48}
                   name={metricKey.replace(/_/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())}
                 />
               </BarChart>
@@ -153,11 +153,7 @@ export function AnalysisResult({ result, plan }: AnalysisResultProps) {
                 </Pie>
                 <Tooltip
                   wrapperStyle={{ zIndex: 10, overflow: 'visible' as const }}
-                  contentStyle={{
-                    backgroundColor: "hsl(var(--popover))",
-                    border: "1px solid hsl(var(--border))",
-                    borderRadius: "var(--radius)",
-                  }}
+                  contentStyle={TOOLTIP_STYLE}
                 />
                 <Legend
                   verticalAlign="bottom"

--- a/codebenders-dashboard/components/query-history-panel.tsx
+++ b/codebenders-dashboard/components/query-history-panel.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import type { HistoryEntry } from "@/lib/types"
+
+function relativeTime(isoTimestamp: string): string {
+  const now = Date.now()
+  const then = new Date(isoTimestamp).getTime()
+  const diffMs = now - then
+
+  if (diffMs < 0) return "just now"
+
+  const seconds = Math.floor(diffMs / 1000)
+  if (seconds < 60) return seconds <= 1 ? "just now" : `${seconds} seconds ago`
+
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return minutes === 1 ? "1 minute ago" : `${minutes} minutes ago`
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return hours === 1 ? "1 hour ago" : `${hours} hours ago`
+
+  const days = Math.floor(hours / 24)
+  if (days < 30) return days === 1 ? "1 day ago" : `${days} days ago`
+
+  const months = Math.floor(days / 30)
+  if (months < 12) return months === 1 ? "1 month ago" : `${months} months ago`
+
+  const years = Math.floor(months / 12)
+  return years === 1 ? "1 year ago" : `${years} years ago`
+}
+
+interface QueryHistoryPanelProps {
+  entries: HistoryEntry[]
+  onRerun: (entry: HistoryEntry) => void
+  onClear: () => void
+}
+
+export function QueryHistoryPanel({ entries, onRerun, onClear }: QueryHistoryPanelProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-base font-semibold">Recent Queries</CardTitle>
+        <Button variant="ghost" size="sm" onClick={onClear}>
+          Clear
+        </Button>
+      </CardHeader>
+      <CardContent className="p-0">
+        <ul className="divide-y divide-border">
+          {/* Entries arrive pre-sorted: newest first from page.tsx */}
+          {entries.map((entry) => {
+            const truncated =
+              entry.prompt.length > 60
+                ? entry.prompt.slice(0, 60) + "…"
+                : entry.prompt
+
+            return (
+              <li
+                key={entry.id}
+                className="flex items-center justify-between gap-3 px-6 py-3"
+              >
+                <div className="flex flex-col gap-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-xs text-muted-foreground">
+                      {relativeTime(entry.timestamp)}
+                    </span>
+                    <Badge variant="outline" className="text-xs">
+                      {entry.institution}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      {entry.rowCount} rows
+                    </span>
+                  </div>
+                  <span
+                    className="text-sm truncate"
+                    title={entry.prompt}
+                  >
+                    {truncated}
+                  </span>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onRerun(entry)}
+                  className="shrink-0"
+                >
+                  Re-run
+                </Button>
+              </li>
+            )
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  )
+}

--- a/codebenders-dashboard/components/query-plan-panel.tsx
+++ b/codebenders-dashboard/components/query-plan-panel.tsx
@@ -56,13 +56,6 @@ export function QueryPlanPanel({ plan }: QueryPlanPanelProps) {
         </div>
 
         <div className="space-y-2">
-          <div className="text-sm font-medium text-foreground">API Query String</div>
-          <div className="rounded-md bg-muted p-3 font-mono text-xs text-muted-foreground overflow-x-auto whitespace-pre-wrap break-all">
-            {plan.queryString}
-          </div>
-        </div>
-
-        <div className="space-y-2">
           <div className="text-sm font-medium text-foreground">SQL (Reference)</div>
           <div className="rounded-md bg-muted p-3 font-mono text-xs text-muted-foreground overflow-x-auto whitespace-pre-wrap break-words">
             {plan.sql}

--- a/codebenders-dashboard/components/retention-risk-chart.tsx
+++ b/codebenders-dashboard/components/retention-risk-chart.tsx
@@ -64,7 +64,7 @@ export function RetentionRiskChart({ data, loading = false, info }: RetentionRis
 
   const chartData = data.map(item => ({
     category: item.category,
-    count: item.count,
+    count: Number(item.count),
     percentage: item.percentage,
   }))
 

--- a/codebenders-dashboard/components/risk-alert-chart.tsx
+++ b/codebenders-dashboard/components/risk-alert-chart.tsx
@@ -84,7 +84,7 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
 
   const chartData = data.map(item => ({
     name: item.category,
-    value: item.count,
+    value: Number(item.count),
     percentage: item.percentage,
   }))
 

--- a/codebenders-dashboard/lib/types.ts
+++ b/codebenders-dashboard/lib/types.ts
@@ -13,6 +13,15 @@ export interface QueryResult {
   rowCount: number
 }
 
+export interface HistoryEntry {
+  id: string
+  timestamp: string   // ISO 8601
+  institution: string // institution code e.g. "bscc"
+  prompt: string
+  rowCount: number
+  vizType: QueryPlan["vizType"]
+}
+
 export interface PDPRecord {
   student_id: string
   institution: string


### PR DESCRIPTION
## Summary

Four UX improvements to the SQL Query Interface. Closes #61.

- **Raw data table below charts** — every chart viz (bar/line/pie/kpi) now shows a scrollable raw data table beneath the visualization so users can verify the numbers behind the chart
- **Chart aspect ratios** — replaced fixed `height={400}` with `aspect` props: `16/7` for bar/line, `4/3` for pie with relative `outerRadius="40%"`, `h-48` for KPI and empty state
- **Tooltip overflow fixed** — `wrapperStyle={{ zIndex: 10, overflow: 'visible' }}` on all chart Tooltips; `ResponsiveContainers` wrapped in `overflow-visible` divs so tooltips are no longer clipped at chart edges
- **Prompt history panel** — query history persisted to `localStorage` (50-entry cap), rendered in a panel between controls and results with relative timestamps, institution badge, row count, and per-entry Re-run buttons; Clear all button; fire-and-forget POST to `/api/query-history` for server-side JSONL audit log

## Commits

- `fix: chart ratios, tooltip overflow, and raw data table below viz` — `components/analysis-result.tsx`
- `feat: add POST /api/query-history for server-side audit logging` — `app/api/query-history/route.ts`, `logs/` added to `.gitignore`
- `feat: add prompt history panel with localStorage persistence and re-run` — `lib/types.ts`, `components/query-history-panel.tsx`, `app/query/page.tsx`

## Test plan

- [ ] Run a bar/line/pie/kpi query — confirm raw data table appears below the chart
- [ ] Hover chart tooltip near edges — confirm it is not clipped
- [ ] Charts look proportional at different viewport widths (bar/line: wide, pie: slightly tall but not square)
- [ ] Run 2+ queries — confirm history panel appears with correct timestamps, institution, prompt, and row count
- [ ] Click Re-run on a history entry — confirm institution + prompt restore and query executes
- [ ] Click Clear — confirm panel disappears and localStorage is empty
- [ ] Refresh page — confirm history is restored from localStorage
- [ ] Check `logs/query-history.jsonl` exists with one JSONL entry per successful query
- [ ] `npm run build` passes with no TypeScript errors

Closes #61