### PR TITLE
feat: dashboard filtering by cohort, enrollment type, and credential type (#66)

### DIFF
--- a/codebenders-dashboard/app/api/dashboard/kpis/route.ts
+++ b/codebenders-dashboard/app/api/dashboard/kpis/route.ts
@@ -3,20 +3,44 @@ import { getPool } from "@/lib/db"
 
 export async function GET(request: NextRequest) {
   try {
+    const { searchParams } = new URL(request.url)
+    const cohort        = searchParams.get("cohort")        || ""
+    const enrollmentType = searchParams.get("enrollmentType") || ""
+    const credentialType = searchParams.get("credentialType") || ""
+
     const pool = getPool()
+
+    const conditions: string[] = []
+    const params: unknown[]    = []
+
+    if (cohort) {
+      params.push(cohort)
+      conditions.push(`"Cohort" = $${params.length}`)
+    }
+    if (enrollmentType) {
+      params.push(enrollmentType)
+      conditions.push(`"Enrollment_Intensity_First_Term" = $${params.length}`)
+    }
+    if (credentialType) {
+      params.push(credentialType)
+      conditions.push(`predicted_credential_label = $${params.length}`)
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
 
     const sql = `
       SELECT
-        AVG("Retention") * 100 as overall_retention_rate,
-        AVG(retention_probability) * 100 as avg_predicted_retention,
-        SUM(CASE WHEN at_risk_alert IN ('HIGH', 'URGENT') THEN 1 ELSE 0 END) as high_critical_risk_count,
-        AVG(course_completion_rate) * 100 as avg_course_completion_rate,
-        COUNT(*) as total_students
+        AVG("Retention") * 100                                                       AS overall_retention_rate,
+        AVG(retention_probability) * 100                                             AS avg_predicted_retention,
+        SUM(CASE WHEN at_risk_alert IN ('HIGH', 'URGENT') THEN 1 ELSE 0 END)        AS high_critical_risk_count,
+        AVG(course_completion_rate) * 100                                            AS avg_course_completion_rate,
+        COUNT(*)                                                                     AS total_students
       FROM student_level_with_predictions
+      ${where}
       LIMIT 1
     `
 
-    const result = await pool.query(sql)
+    const result = await pool.query(sql, params)
     const kpis = result.rows[0] ?? null
 
     if (!kpis) {
@@ -24,17 +48,17 @@ export async function GET(request: NextRequest) {
     }
 
     return NextResponse.json({
-      overallRetentionRate: Number(kpis.overall_retention_rate || 0).toFixed(1),
-      avgPredictedRetention: Number(kpis.avg_predicted_retention || 0).toFixed(1),
-      highCriticalRiskCount: Number(kpis.high_critical_risk_count || 0),
+      overallRetentionRate:    Number(kpis.overall_retention_rate    || 0).toFixed(1),
+      avgPredictedRetention:   Number(kpis.avg_predicted_retention   || 0).toFixed(1),
+      highCriticalRiskCount:   Number(kpis.high_critical_risk_count  || 0),
       avgCourseCompletionRate: Number(kpis.avg_course_completion_rate || 0).toFixed(1),
-      totalStudents: Number(kpis.total_students || 0),
+      totalStudents:           Number(kpis.total_students            || 0),
     })
   } catch (error) {
     console.error("KPI fetch error:", error)
     return NextResponse.json(
       {
-        error: "Failed to fetch KPIs",
+        error:   "Failed to fetch KPIs",
         details: error instanceof Error ? error.message : String(error),
       },
       { status: 500 }

--- a/codebenders-dashboard/app/api/dashboard/readiness/route.ts
+++ b/codebenders-dashboard/app/api/dashboard/readiness/route.ts
@@ -4,31 +4,49 @@ import { getPool } from "@/lib/db"
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url)
-    const institution = searchParams.get("institution")
-    const cohort = searchParams.get("cohort")
-    const level = searchParams.get("level") // high, medium, low
+    const institution    = searchParams.get("institution")
+    const cohort         = searchParams.get("cohort")
+    const level          = searchParams.get("level")          // high, medium, low
+    const enrollmentType = searchParams.get("enrollmentType")
+    const credentialType = searchParams.get("credentialType")
 
     const pool = getPool()
 
-    // Build WHERE clause with $N Postgres placeholders
+    // Build WHERE clause with $N Postgres placeholders.
+    // llm_recommendations is aliased as lr; when enrollment/credential filters are
+    // present we JOIN student_level_with_predictions as s.
     const conditions: string[] = []
-    const params: any[] = []
+    const params: unknown[]    = []
 
     if (institution) {
       params.push(institution)
-      conditions.push(`"Institution_ID" = $${params.length}`)
+      conditions.push(`lr."Institution_ID" = $${params.length}`)
     }
 
     if (cohort) {
       params.push(cohort)
-      conditions.push(`"Cohort" = $${params.length}`)
+      conditions.push(`lr."Cohort" = $${params.length}`)
     }
 
     if (level) {
       params.push(level)
-      conditions.push(`readiness_level = $${params.length}`)
+      conditions.push(`lr.readiness_level = $${params.length}`)
     }
 
+    if (enrollmentType) {
+      params.push(enrollmentType)
+      conditions.push(`s."Enrollment_Intensity_First_Term" = $${params.length}`)
+    }
+
+    if (credentialType) {
+      params.push(credentialType)
+      conditions.push(`s.predicted_credential_label = $${params.length}`)
+    }
+
+    const needsJoin  = !!(enrollmentType || credentialType)
+    const joinClause = needsJoin
+      ? `JOIN student_level_with_predictions s ON s."Student_GUID" = lr."Student_GUID"`
+      : ""
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
 
     // Get overall statistics
@@ -36,13 +54,14 @@ export async function GET(request: Request) {
       `
       SELECT
         COUNT(*) as total_students,
-        AVG(readiness_score) as avg_score,
-        MIN(readiness_score) as min_score,
-        MAX(readiness_score) as max_score,
-        SUM(CASE WHEN readiness_level = 'high' THEN 1 ELSE 0 END) as high_count,
-        SUM(CASE WHEN readiness_level = 'medium' THEN 1 ELSE 0 END) as medium_count,
-        SUM(CASE WHEN readiness_level = 'low' THEN 1 ELSE 0 END) as low_count
-      FROM llm_recommendations
+        AVG(lr.readiness_score) as avg_score,
+        MIN(lr.readiness_score) as min_score,
+        MAX(lr.readiness_score) as max_score,
+        SUM(CASE WHEN lr.readiness_level = 'high'   THEN 1 ELSE 0 END) as high_count,
+        SUM(CASE WHEN lr.readiness_level = 'medium' THEN 1 ELSE 0 END) as medium_count,
+        SUM(CASE WHEN lr.readiness_level = 'low'    THEN 1 ELSE 0 END) as low_count
+      FROM llm_recommendations lr
+      ${joinClause}
       ${whereClause}
     `,
       params
@@ -58,19 +77,20 @@ export async function GET(request: Request) {
     const distributionResult = await pool.query(
       `
       SELECT
-        readiness_level,
+        lr.readiness_level,
         COUNT(*) as count,
-        AVG(readiness_score) as avg_score,
-        MIN(readiness_score) as min_score,
-        MAX(readiness_score) as max_score
-      FROM llm_recommendations
+        AVG(lr.readiness_score) as avg_score,
+        MIN(lr.readiness_score) as min_score,
+        MAX(lr.readiness_score) as max_score
+      FROM llm_recommendations lr
+      ${joinClause}
       ${whereClause}
-      GROUP BY readiness_level
+      GROUP BY lr.readiness_level
       ORDER BY
-        CASE readiness_level
-          WHEN 'high' THEN 1
+        CASE lr.readiness_level
+          WHEN 'high'   THEN 1
           WHEN 'medium' THEN 2
-          WHEN 'low' THEN 3
+          WHEN 'low'    THEN 3
         END
     `,
       params
@@ -81,21 +101,22 @@ export async function GET(request: Request) {
       `
       SELECT
         CASE
-          WHEN readiness_score >= 0.8 THEN '0.8-1.0'
-          WHEN readiness_score >= 0.6 THEN '0.6-0.8'
-          WHEN readiness_score >= 0.4 THEN '0.4-0.6'
-          WHEN readiness_score >= 0.2 THEN '0.2-0.4'
+          WHEN lr.readiness_score >= 0.8 THEN '0.8-1.0'
+          WHEN lr.readiness_score >= 0.6 THEN '0.6-0.8'
+          WHEN lr.readiness_score >= 0.4 THEN '0.4-0.6'
+          WHEN lr.readiness_score >= 0.2 THEN '0.2-0.4'
           ELSE '0.0-0.2'
         END as score_range,
         COUNT(*) as count
-      FROM llm_recommendations
+      FROM llm_recommendations lr
+      ${joinClause}
       ${whereClause}
       GROUP BY
         CASE
-          WHEN readiness_score >= 0.8 THEN '0.8-1.0'
-          WHEN readiness_score >= 0.6 THEN '0.6-0.8'
-          WHEN readiness_score >= 0.4 THEN '0.4-0.6'
-          WHEN readiness_score >= 0.2 THEN '0.2-0.4'
+          WHEN lr.readiness_score >= 0.8 THEN '0.8-1.0'
+          WHEN lr.readiness_score >= 0.6 THEN '0.6-0.8'
+          WHEN lr.readiness_score >= 0.4 THEN '0.4-0.6'
+          WHEN lr.readiness_score >= 0.2 THEN '0.2-0.4'
           ELSE '0.0-0.2'
         END
       ORDER BY score_range DESC
@@ -120,6 +141,7 @@ export async function GET(request: Request) {
         lr.generated_at,
         lr.model_name
       FROM llm_recommendations lr
+      ${joinClause}
       ${whereClause}
       ORDER BY lr.generated_at DESC
       LIMIT 100
@@ -130,15 +152,16 @@ export async function GET(request: Request) {
     // Parse JSON fields in recent assessments
     const assessments = recentResult.rows.map((row) => ({
       ...row,
-      risk_factors: row.risk_factors ? JSON.parse(row.risk_factors) : [],
+      risk_factors:      row.risk_factors      ? JSON.parse(row.risk_factors)      : [],
       suggested_actions: row.suggested_actions ? JSON.parse(row.suggested_actions) : [],
     }))
 
     // Get most common risk factors
     const riskFactorResult = await pool.query(
       `
-      SELECT risk_factors
-      FROM llm_recommendations
+      SELECT lr.risk_factors
+      FROM llm_recommendations lr
+      ${joinClause}
       ${whereClause}
     `,
       params
@@ -172,16 +195,17 @@ export async function GET(request: Request) {
     const cohortResult = await pool.query(
       `
       SELECT
-        "Cohort",
+        lr."Cohort",
         COUNT(*) as total,
-        AVG(readiness_score) as avg_score,
-        SUM(CASE WHEN readiness_level = 'high' THEN 1 ELSE 0 END) as high_count,
-        SUM(CASE WHEN readiness_level = 'medium' THEN 1 ELSE 0 END) as medium_count,
-        SUM(CASE WHEN readiness_level = 'low' THEN 1 ELSE 0 END) as low_count
-      FROM llm_recommendations
+        AVG(lr.readiness_score) as avg_score,
+        SUM(CASE WHEN lr.readiness_level = 'high'   THEN 1 ELSE 0 END) as high_count,
+        SUM(CASE WHEN lr.readiness_level = 'medium' THEN 1 ELSE 0 END) as medium_count,
+        SUM(CASE WHEN lr.readiness_level = 'low'    THEN 1 ELSE 0 END) as low_count
+      FROM llm_recommendations lr
+      ${joinClause}
       ${whereClause}
-      GROUP BY "Cohort"
-      ORDER BY "Cohort" DESC
+      GROUP BY lr."Cohort"
+      ORDER BY lr."Cohort" DESC
     `,
       params
     )
@@ -191,16 +215,16 @@ export async function GET(request: Request) {
       data: {
         summary: {
           total_students: stats.total_students,
-          avg_score: parseFloat(stats.avg_score || 0).toFixed(4),
-          min_score: parseFloat(stats.min_score || 0).toFixed(4),
-          max_score: parseFloat(stats.max_score || 0).toFixed(4),
-          high_count: stats.high_count,
-          medium_count: stats.medium_count,
-          low_count: stats.low_count,
+          avg_score:      parseFloat(stats.avg_score || 0).toFixed(4),
+          min_score:      parseFloat(stats.min_score || 0).toFixed(4),
+          max_score:      parseFloat(stats.max_score || 0).toFixed(4),
+          high_count:     stats.high_count,
+          medium_count:   stats.medium_count,
+          low_count:      stats.low_count,
         },
-        distribution: distributionResult.rows,
+        distribution:     distributionResult.rows,
         score_distribution: scoreDistResult.rows,
-        assessments: assessments,
+        assessments:      assessments,
         top_risk_factors: topRiskFactors,
         cohort_breakdown: cohortResult.rows,
       },
@@ -211,7 +235,7 @@ export async function GET(request: Request) {
     return NextResponse.json(
       {
         success: false,
-        error: "Failed to fetch readiness assessment data",
+        error:   "Failed to fetch readiness assessment data",
         details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }

--- a/codebenders-dashboard/app/api/dashboard/retention-risk/route.ts
+++ b/codebenders-dashboard/app/api/dashboard/retention-risk/route.ts
@@ -3,27 +3,57 @@ import { getPool } from "@/lib/db"
 
 export async function GET(request: NextRequest) {
   try {
+    const { searchParams } = new URL(request.url)
+    const cohort         = searchParams.get("cohort")         || ""
+    const enrollmentType = searchParams.get("enrollmentType") || ""
+    const credentialType = searchParams.get("credentialType") || ""
+
     const pool = getPool()
 
+    const conditions: string[] = []
+    const params: unknown[]    = []
+
+    if (cohort) {
+      params.push(cohort)
+      conditions.push(`"Cohort" = $${params.length}`)
+    }
+    if (enrollmentType) {
+      params.push(enrollmentType)
+      conditions.push(`"Enrollment_Intensity_First_Term" = $${params.length}`)
+    }
+    if (credentialType) {
+      params.push(credentialType)
+      conditions.push(`predicted_credential_label = $${params.length}`)
+    }
+
+    const baseWhere = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
+
+    // Use a CTE so the percentage denominator is relative to the filtered set
     const sql = `
+      WITH filtered AS (
+        SELECT retention_risk_category
+        FROM student_level_with_predictions
+        ${baseWhere}
+      ),
+      total AS (SELECT COUNT(*) AS n FROM filtered)
       SELECT
-        retention_risk_category as category,
-        COUNT(*) as count,
-        ROUND(COUNT(*) * 100.0 / (SELECT COUNT(*) FROM student_level_with_predictions), 1) as percentage
-      FROM student_level_with_predictions
+        retention_risk_category                                              AS category,
+        COUNT(*)                                                             AS count,
+        ROUND(COUNT(*) * 100.0 / NULLIF((SELECT n FROM total), 0), 1)      AS percentage
+      FROM filtered
       WHERE retention_risk_category IS NOT NULL
       GROUP BY retention_risk_category
       ORDER BY
         CASE retention_risk_category
-          WHEN 'Critical Risk' THEN 1
-          WHEN 'High Risk' THEN 2
-          WHEN 'Moderate Risk' THEN 3
-          WHEN 'Low Risk' THEN 4
+          WHEN 'Critical Risk'  THEN 1
+          WHEN 'High Risk'      THEN 2
+          WHEN 'Moderate Risk'  THEN 3
+          WHEN 'Low Risk'       THEN 4
           ELSE 5
         END
     `
 
-    const result = await pool.query(sql)
+    const result = await pool.query(sql, params)
 
     return NextResponse.json({
       data: result.rows,
@@ -32,7 +62,7 @@ export async function GET(request: NextRequest) {
     console.error("Retention risk fetch error:", error)
     return NextResponse.json(
       {
-        error: "Failed to fetch retention risk data",
+        error:   "Failed to fetch retention risk data",
         details: error instanceof Error ? error.message : String(error),
       },
       { status: 500 }

--- a/codebenders-dashboard/app/api/dashboard/risk-alerts/route.ts
+++ b/codebenders-dashboard/app/api/dashboard/risk-alerts/route.ts
@@ -3,27 +3,57 @@ import { getPool } from "@/lib/db"
 
 export async function GET(request: NextRequest) {
   try {
+    const { searchParams } = new URL(request.url)
+    const cohort         = searchParams.get("cohort")         || ""
+    const enrollmentType = searchParams.get("enrollmentType") || ""
+    const credentialType = searchParams.get("credentialType") || ""
+
     const pool = getPool()
 
+    const conditions: string[] = []
+    const params: unknown[]    = []
+
+    if (cohort) {
+      params.push(cohort)
+      conditions.push(`"Cohort" = $${params.length}`)
+    }
+    if (enrollmentType) {
+      params.push(enrollmentType)
+      conditions.push(`"Enrollment_Intensity_First_Term" = $${params.length}`)
+    }
+    if (credentialType) {
+      params.push(credentialType)
+      conditions.push(`predicted_credential_label = $${params.length}`)
+    }
+
+    const baseWhere = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
+
+    // Use a CTE so the percentage denominator is relative to the filtered set
     const sql = `
+      WITH filtered AS (
+        SELECT at_risk_alert
+        FROM student_level_with_predictions
+        ${baseWhere}
+      ),
+      total AS (SELECT COUNT(*) AS n FROM filtered)
       SELECT
-        at_risk_alert as category,
-        COUNT(*) as count,
-        ROUND(COUNT(*) * 100.0 / (SELECT COUNT(*) FROM student_level_with_predictions), 1) as percentage
-      FROM student_level_with_predictions
+        at_risk_alert                                                        AS category,
+        COUNT(*)                                                             AS count,
+        ROUND(COUNT(*) * 100.0 / NULLIF((SELECT n FROM total), 0), 1)      AS percentage
+      FROM filtered
       WHERE at_risk_alert IS NOT NULL
       GROUP BY at_risk_alert
       ORDER BY
         CASE at_risk_alert
-          WHEN 'URGENT' THEN 1
-          WHEN 'HIGH' THEN 2
+          WHEN 'URGENT'   THEN 1
+          WHEN 'HIGH'     THEN 2
           WHEN 'MODERATE' THEN 3
-          WHEN 'LOW' THEN 4
+          WHEN 'LOW'      THEN 4
           ELSE 5
         END
     `
 
-    const result = await pool.query(sql)
+    const result = await pool.query(sql, params)
 
     return NextResponse.json({
       data: result.rows,
@@ -32,7 +62,7 @@ export async function GET(request: NextRequest) {
     console.error("Risk alerts fetch error:", error)
     return NextResponse.json(
       {
-        error: "Failed to fetch risk alerts",
+        error:   "Failed to fetch risk alerts",
         details: error instanceof Error ? error.message : String(error),
       },
       { status: 500 }

--- a/codebenders-dashboard/app/page.tsx
+++ b/codebenders-dashboard/app/page.tsx
@@ -7,7 +7,14 @@ import { RetentionRiskChart } from "@/components/retention-risk-chart"
 import { ReadinessAssessmentChart } from "@/components/readiness-assessment-chart"
 import { ExportButton } from "@/components/export-button"
 import { Button } from "@/components/ui/button"
-import { TrendingUp, Users, AlertTriangle, BookOpen, Search, Table2 } from "lucide-react"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { TrendingUp, Users, AlertTriangle, BookOpen, Search, Table2, X } from "lucide-react"
 import Link from "next/link"
 
 interface KPIData {
@@ -47,6 +54,10 @@ interface ReadinessData {
   cohort_breakdown: any[]
 }
 
+const COHORTS        = ["2019-20", "2020-21", "2021-22", "2022-23", "2023-24"]
+const ENROLLMENT_TYPES = ["Full-Time", "Part-Time"]
+const CREDENTIAL_TYPES = ["Certificate", "Associate", "Bachelor"]
+
 export default function DashboardPage() {
   const [kpis, setKpis] = useState<KPIData | null>(null)
   const [riskAlerts, setRiskAlerts] = useState<RiskAlertData[]>([])
@@ -57,17 +68,34 @@ export default function DashboardPage() {
   const [error, setError] = useState<string | null>(null)
   const [readinessError, setReadinessError] = useState<string | null>(null)
 
+  // Filter state
+  const [cohort, setCohort]               = useState("")
+  const [enrollmentType, setEnrollmentType] = useState("")
+  const [credentialType, setCredentialType] = useState("")
+
+  const hasFilters = !!(cohort || enrollmentType || credentialType)
+
+  function buildFilterParams() {
+    const p = new URLSearchParams()
+    if (cohort)         p.set("cohort", cohort)
+    if (enrollmentType) p.set("enrollmentType", enrollmentType)
+    if (credentialType) p.set("credentialType", credentialType)
+    const qs = p.toString()
+    return qs ? `?${qs}` : ""
+  }
+
   useEffect(() => {
+    const qs = buildFilterParams()
+
     const fetchDashboardData = async () => {
       try {
         setLoading(true)
         setError(null)
 
-        // Fetch all data in parallel
         const [kpisRes, riskAlertsRes, retentionRiskRes] = await Promise.all([
-          fetch("/api/dashboard/kpis"),
-          fetch("/api/dashboard/risk-alerts"),
-          fetch("/api/dashboard/retention-risk"),
+          fetch(`/api/dashboard/kpis${qs}`),
+          fetch(`/api/dashboard/risk-alerts${qs}`),
+          fetch(`/api/dashboard/retention-risk${qs}`),
         ])
 
         if (!kpisRes.ok || !riskAlertsRes.ok || !retentionRiskRes.ok) {
@@ -96,14 +124,14 @@ export default function DashboardPage() {
         setReadinessLoading(true)
         setReadinessError(null)
 
-        const response = await fetch("/api/dashboard/readiness")
-        
+        const response = await fetch(`/api/dashboard/readiness${qs}`)
+
         if (!response.ok) {
           throw new Error("Failed to fetch readiness assessment data")
         }
 
         const result = await response.json()
-        
+
         if (result.success) {
           setReadinessData(result.data ?? null)
         } else {
@@ -119,7 +147,8 @@ export default function DashboardPage() {
 
     fetchDashboardData()
     fetchReadinessData()
-  }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cohort, enrollmentType, credentialType])
 
   return (
     <div className="min-h-screen bg-background">
@@ -135,11 +164,11 @@ export default function DashboardPage() {
             </p>
           </div>
           <div className="flex gap-2">
-            <ExportButton 
+            <ExportButton
               data={{
                 kpis,
                 riskAlerts,
-                retentionRisk
+                retentionRisk,
               }}
               disabled={loading || !kpis}
             />
@@ -162,6 +191,67 @@ export default function DashboardPage() {
               </Button>
             </Link>
           </div>
+        </div>
+
+        {/* Filter Bar */}
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-sm font-medium text-muted-foreground">Filter by:</span>
+
+          <Select value={cohort} onValueChange={setCohort}>
+            <SelectTrigger className="w-36">
+              <SelectValue placeholder="Cohort" />
+            </SelectTrigger>
+            <SelectContent>
+              {COHORTS.map((c) => (
+                <SelectItem key={c} value={c}>{c}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select value={enrollmentType} onValueChange={setEnrollmentType}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Enrollment Type" />
+            </SelectTrigger>
+            <SelectContent>
+              {ENROLLMENT_TYPES.map((e) => (
+                <SelectItem key={e} value={e}>{e}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select value={credentialType} onValueChange={setCredentialType}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Credential Type" />
+            </SelectTrigger>
+            <SelectContent>
+              {CREDENTIAL_TYPES.map((c) => (
+                <SelectItem key={c} value={c}>{c}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {hasFilters && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-1 text-muted-foreground"
+              onClick={() => {
+                setCohort("")
+                setEnrollmentType("")
+                setCredentialType("")
+              }}
+            >
+              <X className="h-3 w-3" />
+              Clear
+            </Button>
+          )}
+
+          {hasFilters && (
+            <span className="text-xs text-muted-foreground">
+              Showing filtered results
+              {kpis ? ` · ${kpis.totalStudents.toLocaleString()} students` : ""}
+            </span>
+          )}
         </div>
 
         {/* Error State */}
@@ -256,8 +346,8 @@ export default function DashboardPage() {
 
         {/* Charts */}
         <div className="grid gap-6 md:grid-cols-2">
-          <RiskAlertChart 
-            data={riskAlerts} 
+          <RiskAlertChart
+            data={riskAlerts}
             loading={loading}
             info={
               <>
@@ -281,8 +371,8 @@ export default function DashboardPage() {
               </>
             }
           />
-          <RetentionRiskChart 
-            data={retentionRisk} 
+          <RetentionRiskChart
+            data={retentionRisk}
             loading={loading}
             info={
               <>
@@ -311,7 +401,7 @@ export default function DashboardPage() {
               AI-powered analysis identifying student preparation levels and intervention needs
             </p>
           </div>
-          <ReadinessAssessmentChart 
+          <ReadinessAssessmentChart
             data={readinessData}
             isLoading={readinessLoading}
             error={readinessError || undefined}


### PR DESCRIPTION
## Summary

- Adds a **filter bar** above the KPI tiles on the main dashboard with three dropdowns: Cohort (2019-20 → 2023-24), Enrollment Type (Full-Time / Part-Time), and Credential Type (Certificate / Associate / Bachelor)
- A **Clear** button appears when any filter is active, along with a filtered student count
- All four dashboard API routes (`/kpis`, `/risk-alerts`, `/retention-risk`, `/readiness`) now accept `cohort`, `enrollmentType`, and `credentialType` query params
- **Percentage denominators** in the risk-alerts and retention-risk charts are now relative to the filtered subset (uses a CTE instead of a hard-coded full-table subquery)
- The readiness route conditionally JOINs `student_level_with_predictions` when enrollment/credential filters are active, keeping existing `institution`/`cohort`/`level` params unchanged
- All data re-fetches automatically when filter state changes

## Test plan

- [ ] Load dashboard — all charts and KPIs show unfiltered totals
- [ ] Select a cohort (e.g. "2022-23") — KPI counts drop, chart percentages still sum to 100%
- [ ] Select "Part-Time" enrollment — further narrows all four panels
- [ ] Select "Certificate" credential type — readiness chart reflects filtered set
- [ ] Click Clear — all panels return to full-population values
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)

Closes #66