### PR TITLE
feat: audit log export endpoint with CSV download button (#67)

### DIFF
--- a/codebenders-dashboard/app/api/query-history/export/route.ts
+++ b/codebenders-dashboard/app/api/query-history/export/route.ts
@@ -1,0 +1,75 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { readFile } from "fs/promises"
+import path from "path"
+
+const LOG_FILE = path.join(process.cwd(), "logs", "query-history.jsonl")
+
+function escapeCsvField(value: unknown): string {
+  const str = String(value ?? "")
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const fromParam = searchParams.get("from")
+  const toParam   = searchParams.get("to")
+
+  const fromDate = fromParam ? new Date(fromParam) : null
+  const toDate   = toParam   ? new Date(toParam)   : null
+
+  let raw: string
+  try {
+    raw = await readFile(LOG_FILE, "utf-8")
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === "ENOENT") {
+      return NextResponse.json({ error: "Audit log does not exist yet" }, { status: 404 })
+    }
+    return NextResponse.json({ error: "Failed to read audit log" }, { status: 500 })
+  }
+
+  const lines = raw.split("\n").filter(Boolean)
+
+  const rows: string[] = [
+    ["timestamp", "institution", "prompt", "vizType", "rowCount"].join(","),
+  ]
+
+  for (const line of lines) {
+    let entry: Record<string, unknown>
+    try {
+      entry = JSON.parse(line)
+    } catch {
+      continue
+    }
+
+    // Date-range filter
+    if (fromDate || toDate) {
+      const ts = new Date(entry.timestamp as string)
+      if (fromDate && ts < fromDate) continue
+      if (toDate   && ts > toDate)   continue
+    }
+
+    rows.push(
+      [
+        escapeCsvField(entry.timestamp),
+        escapeCsvField(entry.institution),
+        escapeCsvField(entry.prompt),
+        escapeCsvField(entry.vizType),
+        escapeCsvField(entry.rowCount),
+      ].join(",")
+    )
+  }
+
+  const csv = rows.join("\n")
+
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "Content-Type":        "text/csv; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="query-audit-log.csv"',
+    },
+  })
+}

--- a/codebenders-dashboard/components/query-history-panel.tsx
+++ b/codebenders-dashboard/components/query-history-panel.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { Download } from "lucide-react"
 import type { HistoryEntry } from "@/lib/types"
 
 function relativeTime(isoTimestamp: string): string {
@@ -42,9 +43,22 @@ export function QueryHistoryPanel({ entries, onRerun, onClear }: QueryHistoryPan
     <Card>
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <CardTitle className="text-base font-semibold">Recent Queries</CardTitle>
-        <Button variant="ghost" size="sm" onClick={onClear}>
-          Clear
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1"
+            asChild
+          >
+            <a href="/api/query-history/export" download="query-audit-log.csv">
+              <Download className="h-3 w-3" />
+              Export
+            </a>
+          </Button>
+          <Button variant="ghost" size="sm" onClick={onClear}>
+            Clear
+          </Button>
+        </div>
       </CardHeader>
       <CardContent className="p-0">
         <ul className="divide-y divide-border">


### PR DESCRIPTION
## Summary

- Adds `GET /api/query-history/export` — reads `logs/query-history.jsonl` and returns a downloadable CSV
- CSV columns: `timestamp, institution, prompt, vizType, rowCount`
- Optional `?from=ISO_DATE&to=ISO_DATE` query params filter entries by date range
- Returns **404** with a clear message if the log file does not exist yet
- Sets `Content-Disposition: attachment; filename="query-audit-log.csv"`
- Adds an **Export** button (with download icon) in the `QueryHistoryPanel` header that triggers a direct browser download via `<a href download>`

## Test plan

- [ ] Visit `/query`, run a few queries to populate `logs/query-history.jsonl`
- [ ] Click Export in the history panel — browser downloads `query-audit-log.csv` with correct headers and rows
- [ ] Fetch `/api/query-history/export?from=2025-01-01&to=2025-12-31` — only matching rows appear
- [ ] Delete or rename the log file and call the endpoint — returns 404 JSON
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)

Closes #67