### PR TITLE
docs: rewrite README and QUICKSTART for Bishop State deployment (#21)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,154 +1,59 @@
-# 🚀 Quick Start Guide
+# Quick Start
 
-Get up and running with the Bishop State Student Success Prediction project in 5 minutes!
+Get the Bishop State Student Success Analytics stack running in minutes.
 
-## ⚡ Fast Track
+## 1 — Clone
 
 ```bash
-# 1. Install dependencies
+git clone https://github.com/devcolor/codebenders-datathon.git
+cd codebenders-datathon
+```
+
+## 2 — ML Pipeline
+
+```bash
+python -m venv venv
+source venv/bin/activate          # Windows: venv\Scripts\activate
 pip install -r requirements.txt
 
-# 2. Run the ML pipeline
+cp codebenders-dashboard/env.example .env
+# → Edit .env with your Supabase credentials (see README.md)
+
+python -m operations.test_db_connection   # verify DB connection
+
 cd ai_model
-python complete_ml_pipeline.py
-
-# 3. Check results
-# - Console output shows model performance
-# - ML_PIPELINE_REPORT.txt has detailed summary
-# - Predictions saved in ../data/ folder
+python complete_ml_pipeline.py            # ~10-15 min
 ```
 
-## 📂 What's Where?
+## 3 — Dashboard
 
-```
-codebenders-datathon/
-├── ai_model/              # ML scripts - START HERE
-│   ├── complete_ml_pipeline.py    # Main script (run this!)
-│   ├── merge_bishop_state_data.py # Data merging (optional)
-│   └── generate_bishop_state_data.py  # Synthetic data generation
-│
-├── data/                  # All CSV files and predictions
-│   ├── bishop_state_*_with_zip.csv       # Input data files
-│   ├── bishop_state_*_with_predictions.csv  # Output predictions
-│   └── README.md                         # Data documentation
-│
-├── codebenders-dashboard/ # Next.js web dashboard
-├── README.md              # Full project documentation
-├── DATA_DICTIONARY.md     # Field descriptions
-└── ML_MODELS_GUIDE.md     # Model details
-```
-
-## 🎯 What You Get
-
-Running the pipeline generates predictions for **all students**:
-
-### 5 Prediction Models
-
-1. **Retention** - Will they return? (53% AUC)
-2. **Early Warning** - Are they at risk? (4-level alert system)
-3. **Time-to-Credential** - When will they graduate?
-4. **Credential Type** - What will they earn?
-5. **Course Success** - What will their GPA be?
-
-### Output Files
-
-- `bishop_state_student_level_with_predictions.csv` - One row per student (~4,000)
-- `bishop_state_merged_with_predictions.csv` - One row per course (~99,559)
-- `ML_PIPELINE_REPORT.txt` - Performance summary
-
-## ⏱️ Runtime
-
-- **Total**: ~10-15 minutes
-- Data loading: ~30 seconds
-- Model training: ~5-10 minutes
-- Predictions: ~1 minute
-
-## 🔍 Key Prediction Columns
-
-| Column | What It Tells You |
-|--------|-------------------|
-| `retention_probability` | Chance of returning (0-1) |
-| `retention_risk_category` | Risk level (Critical/High/Moderate/Low) |
-| `at_risk_alert` | Alert level (URGENT/HIGH/MODERATE/LOW) |
-| `risk_score` | Comprehensive risk (0-100) |
-| `predicted_time_to_credential` | Years to graduation |
-| `predicted_credential_label` | Expected credential type |
-| `predicted_gpa` | Expected GPA (0-4) |
-
-## 💡 Common Use Cases
-
-### Find At-Risk Students
-```python
-import pandas as pd
-df = pd.read_csv('data/bishop_state_student_level_with_predictions.csv')
-
-# Students needing urgent intervention
-urgent = df[df['at_risk_alert'] == 'URGENT']
-print(f"Urgent cases: {len(urgent)}")
-
-# High-risk students with low retention probability
-high_risk = df[(df['retention_probability'] < 0.3) &
-               (df['risk_score'] > 70)]
-```
-
-### Identify Overperformers
-```python
-# Students doing better than expected
-overperformers = df[df['gpa_performance'] == 'Above Expected']
-```
-
-### Predict Graduation Timeline
-```python
-# Students likely to graduate in 2-3 years
-on_track = df[(df['predicted_time_to_credential'] >= 2) &
-              (df['predicted_time_to_credential'] <= 3)]
-```
-
-## 🐛 Troubleshooting
-
-### "File not found" error
-Make sure you're in the `ai_model/` directory:
 ```bash
-cd ai_model
-python complete_ml_pipeline.py
+cd codebenders-dashboard
+npm install
+
+cp env.example .env.local
+# → Edit .env.local with your Supabase credentials + OpenAI key
+
+npm run dev      # → http://localhost:3000
 ```
 
-### Memory error
-Reduce model complexity in `complete_ml_pipeline.py`:
-```python
-# Change n_estimators from 200 to 100
-n_estimators=100
-```
+## What the pipeline produces
 
-### Slow performance
-Enable parallel processing (already set for Random Forest):
-```python
-n_jobs=-1  # Use all CPU cores
-```
+Seven models write predictions to the `student_level_with_predictions` table in Supabase:
 
-## 📚 Learn More
+| Column | Description |
+|--------|-------------|
+| `retention_probability` | Probability of returning next year (0–1) |
+| `at_risk_alert` | `URGENT` / `HIGH` / `MODERATE` / `LOW` |
+| `gateway_math_probability` | Probability of passing gateway math (0–1) |
+| `gateway_english_probability` | Probability of passing gateway English (0–1) |
+| `low_gpa_probability` | Probability of GPA < 2.0 (0–1) |
+| `predicted_time_to_credential` | Years to completion |
+| `predicted_credential_label` | `Certificate` / `Associate` / `Bachelor` |
 
-- **[README.md](README.md)** - Full documentation
-- **[data/README.md](data/README.md)** - Data documentation
-- **[DATA_DICTIONARY.md](DATA_DICTIONARY.md)** - Field descriptions
-- **[ML_MODELS_GUIDE.md](ML_MODELS_GUIDE.md)** - Model guide
-- **[codebenders-dashboard/README.md](codebenders-dashboard/README.md)** - Dashboard docs
+## Further reading
 
-## 🎓 Next Steps
-
-1. ✅ Run the pipeline
-2. 📊 Review `ML_PIPELINE_REPORT.txt`
-3. 🔍 Explore prediction files
-4. 📈 Analyze results for your use case
-5. 🎯 Identify students for intervention
-6. 🔧 Customize models (optional)
-
-## 💬 Need Help?
-
-- Check the README files in each folder
-- Review the DATA_DICTIONARY.md for field meanings
-- Open an issue on GitHub
-
----
-
-**Ready to predict student success? Run the pipeline now!** 🚀
+- **[README.md](README.md)** — Architecture diagram, full setup, all features
+- **[docs/demo/DEMO.md](docs/demo/DEMO.md)** — 6-minute demo talk track
+- **[DATA_DICTIONARY.md](DATA_DICTIONARY.md)** — All field definitions
+- **[ML_MODELS_GUIDE.md](ML_MODELS_GUIDE.md)** — Model accuracy & feature importance

--- a/README.md
+++ b/README.md
@@ -1,351 +1,269 @@
-# Bishop State Student Success Prediction
+# Bishop State Student Success Analytics
 
-A comprehensive machine learning pipeline for predicting student success outcomes at Bishop State Community College.
+A full-stack ML + web application that predicts student outcomes for **Bishop State Community College**. Seven machine learning models generate retention predictions, early warnings, time-to-credential estimates, credential type forecasts, GPA predictions, and gateway course probability scores for ~4,000 students. Results are surfaced through a live Next.js dashboard backed by Supabase Postgres.
 
-## 📋 Table of Contents
+**Live demo:** [https://codebenders-datathon.vercel.app](https://codebenders-datathon.vercel.app)
+**Demo walk-through:** [docs/demo/DEMO.md](docs/demo/DEMO.md)
 
-- [Overview](#overview)
-- [Project Structure](#project-structure)
-- [Features](#features)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Models](#models)
-- [Data](#data)
-- [Output](#output)
-- [Documentation](#documentation)
-- [License](#license)
+---
 
-## 🎯 Overview
-
-This project implements five machine learning models to predict various aspects of student success:
-
-1. **Retention Prediction** - Will the student be retained?
-2. **Early Warning System** - Is the student at risk?
-3. **Time-to-Credential** - How long until graduation?
-4. **Credential Type** - What credential will they earn?
-5. **Course Success** - What will their GPA be?
-
-The models use demographic, academic preparation, enrollment, and course performance data to generate actionable predictions for student support services.
-
-## 📁 Project Structure
+## Architecture
 
 ```
-codebenders-datathon/
-├── ai_model/                          # Machine learning models and scripts
-│   ├── __init__.py                    # Package initialization
-│   ├── complete_ml_pipeline.py        # Main ML pipeline (5 models)
-│   ├── generate_bishop_state_data.py  # Synthetic data generation
-│   └── merge_bishop_state_data.py     # Data merging script
-│
-├── data/                              # Data files (CSV and Excel)
-│   ├── ar_bscc_with_zip.csv          # AR data with zip codes
-│   ├── bishop_state_cohorts_with_zip.csv    # Student cohort data
-│   ├── bishop_state_courses.csv             # Course enrollment data
-│   ├── bishop_state_student_level_with_zip.csv              # Student-level aggregated data
-│   ├── bishop_state_student_level_with_predictions.csv      # Student-level with predictions
-│   ├── bishop_state_merged_with_predictions.csv             # Course-level with predictions
-│   └── De-identified PDP AR Files.xlsx                      # Original Excel data
-│
-├── codebenders-dashboard/             # Next.js web application
-├── operations/                        # Database utilities and configuration
-├── DATA_DICTIONARY.md                 # Detailed data field descriptions
-├── ML_MODELS_GUIDE.md                 # Machine learning models guide
-├── requirements.txt                   # Python dependencies
-├── LICENSE                            # MIT License
-└── README.md                          # This file
+┌─────────────────────────────────────────────────────────────┐
+│                        Data Sources                         │
+│  bishop_state_cohorts_with_zip.csv                          │
+│  bishop_state_courses.csv                                   │
+│  bishop_state_student_level_with_zip.csv                    │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│              ML Pipeline  (ai_model/)                       │
+│                                                             │
+│  7 Models (XGBoost + Random Forest + Logistic Regression)   │
+│  ┌──────────────────┐  ┌─────────────────────────────────┐  │
+│  │ Retention (XGB)  │  │ Early Warning (Composite Score) │  │
+│  │ Time-to-Cred(XGB)│  │ Credential Type (RF Classifier) │  │
+│  │ GPA (RF Reg.)    │  │ Gateway Math / English (LR)     │  │
+│  └──────────────────┘  └─────────────────────────────────┘  │
+│                                                             │
+│  Output → student_level_with_predictions table              │
+└────────────────────────┬────────────────────────────────────┘
+                         │  psycopg2 / pgvector
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  Supabase Postgres                          │
+│                                                             │
+│  student_level_with_predictions   (~4,000 rows)            │
+│  llm_recommendations              (~4,000 rows)            │
+│  query_history                    (audit log)               │
+└────────────────────────┬────────────────────────────────────┘
+                         │  pg (node-postgres)
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│           Next.js Dashboard  (codebenders-dashboard/)       │
+│                                                             │
+│  / Dashboard   KPI tiles, risk + readiness charts           │
+│               Filter by cohort / enrollment / credential    │
+│  /students     Paginated roster with sorting & export       │
+│  /query        Natural language → SQL interface (OpenAI)    │
+│  /methodology  Model explainability & readiness formula     │
+│                                                             │
+│  Deploy target: Vercel                                      │
+└─────────────────────────────────────────────────────────────┘
 ```
 
-## ✨ Features
+---
 
-### Prediction Capabilities
+## Quick Start
 
-- **Retention Risk Assessment**: Identify students at risk of not returning
-- **Early Warning Alerts**: Four-level alert system (URGENT, HIGH, MODERATE, LOW)
-- **Graduation Timeline**: Predict time to credential completion
-- **Credential Path**: Forecast credential type (Certificate, Associate's, Bachelor's)
-- **Academic Performance**: Predict expected GPA and identify over/underperformers
-
-### Technical Features
-
-- **XGBoost & Random Forest**: State-of-the-art ensemble methods
-- **Feature Engineering**: 40+ engineered features from raw data
-- **Comprehensive Evaluation**: Multiple metrics for each model
-- **Production-Ready**: Generates predictions for all students
-- **Detailed Reporting**: Automated summary reports with model performance
-
-## 🚀 Installation
-
-### Prerequisites
-
-- Python 3.8 or higher
-- pip package manager
-- Postgres database access via Supabase (for saving predictions)
-
-### Setup
-
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/devcolor/codebenders-datathon.git
-   cd codebenders-datathon
-   ```
-
-2. **Create and activate virtualenv**
-   ```bash
-   python -m venv venv
-   source venv/bin/activate
-   ```
-
-3. **Install dependencies**
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-4. **Configure database** (Optional - will fallback to CSV if not configured)
-
-   Copy `codebenders-dashboard/env.example` to `.env` and update:
-   ```env
-   DB_HOST=127.0.0.1
-   DB_USER=postgres
-   DB_PASSWORD=postgres
-   DB_PORT=54332
-   DB_NAME=postgres
-   DB_SSL=false
-   ```
-
-5. **Start local Supabase** (for local development)
-   ```bash
-   supabase start
-   ```
-
-6. **Test database connection**
-   ```bash
-   python -m operations.test_db_connection
-   ```
-
-7. **Verify data files**
-   Ensure all required CSV files are in the `data/` folder.
-
-## 💻 Usage
-
-### Quick Start
-
-Run the complete ML pipeline:
+### 1 — Clone
 
 ```bash
+git clone https://github.com/devcolor/codebenders-datathon.git
+cd codebenders-datathon
+```
+
+### 2 — ML Pipeline
+
+```bash
+# Create and activate virtualenv
+python -m venv venv
+source venv/bin/activate        # Windows: venv\Scripts\activate
+
+# Install Python dependencies
+pip install -r requirements.txt
+
+# Copy env and set your Supabase credentials (see "Supabase Setup" below)
+cp codebenders-dashboard/env.example .env
+
+# Test DB connection
+python -m operations.test_db_connection
+
+# Run the full pipeline (~10-15 min)
 cd ai_model
 python complete_ml_pipeline.py
 ```
 
-This will:
-1. Test database connection
-2. Load and preprocess data
-3. Train all 5 models
-4. Generate predictions for all students
-5. Save results to **Postgres database** (or CSV files as fallback)
-6. Save model performance metrics to database
-7. Create a summary report
-
-### Data Merging (Optional)
-
-If you need to re-merge the source data files:
+### 3 — Dashboard
 
 ```bash
-cd ai_model
-python merge_bishop_state_data.py
+cd codebenders-dashboard
+
+# Install Node dependencies
+npm install
+
+# Copy env and fill in credentials (see "Supabase Setup" below)
+cp env.example .env.local
+
+# Start dev server
+npm run dev          # → http://localhost:3000
 ```
-
-### Expected Runtime
-
-- Data loading: ~30 seconds
-- Model training: ~5-10 minutes
-- Prediction generation: ~1 minute
-- **Total**: ~10-15 minutes
-
-### Batch Upload to Database
-
-The pipeline uses an efficient batch upload system to save predictions to Postgres:
-
-**Features**:
-- **Automatic batching**: Large datasets are split into manageable chunks (1,000 records per batch)
-- **Progress tracking**: Real-time progress updates during upload
-- **Connection pooling**: SQLAlchemy engine with connection pooling for reliability
-- **Error handling**: Automatic fallback to CSV if database connection fails
-- **Verification**: Automatic record count verification after upload
-
-**Example Output**:
-```
-Saving 99,559 records to table 'course_predictions'...
-✓ Successfully saved to 'course_predictions'
-  - Records: 99,559
-  - Columns: 45
-  - Verified: 99,559 records in database
-```
-
-**Configuration**:
-- Default batch size: 1,000 records per chunk
-- Adjustable via `chunksize` parameter in `save_dataframe_to_db()`
-- Located in `operations/db_utils.py`
-
-**Tables Created**:
-1. `student_predictions` - Student-level predictions (~4,000 records)
-2. `course_predictions` - Course-level predictions (~99,559 records)
-3. `ml_model_performance` - Model metrics and training history
-
-For more details, see [operations/README.md](operations/README.md).
-
-## 🤖 Models
-
-### 1. Retention Prediction Model
-
-**Algorithm**: XGBoost Classifier
-**Target**: Binary (Retained / Not Retained)
-**Features**: 40+ demographic, academic, and performance features
-
-**Output**:
-- `retention_probability`: Probability of retention (0-1)
-- `retention_prediction`: Binary prediction (0/1)
-- `retention_risk_category`: Risk level (Critical/High/Moderate/Low)
-
-### 2. Early Warning System
-
-**Algorithm**: Composite Risk Score
-**Target**: Binary (At Risk / Not At Risk)
-**Approach**: Combines retention probability with performance metrics
-
-**Risk Factors**:
-- Retention probability (50% weight)
-- GPA performance (20% weight)
-- Course completion rate (20% weight)
-- Credit progress (10% weight)
-
-**Output**:
-- `risk_score`: Comprehensive risk score (0-100)
-- `at_risk_alert`: Alert level (URGENT/HIGH/MODERATE/LOW)
-- `at_risk_probability`: Risk probability (0-1)
-- `at_risk_prediction`: Binary prediction (0/1)
-
-### 3. Time-to-Credential Model
-
-**Algorithm**: XGBoost Regressor
-**Target**: Continuous (Years to credential)
-
-**Output**:
-- `predicted_time_to_credential`: Years to completion
-- `predicted_graduation_year`: Expected graduation year
-
-### 4. Credential Type Model
-
-**Algorithm**: Random Forest Classifier
-**Target**: Multi-class (No Credential / Certificate / Associate's / Bachelor's)
-
-**Output**:
-- `predicted_credential_type`: Numeric code (0-3)
-- `predicted_credential_label`: Text label
-- `prob_no_credential`, `prob_certificate`, `prob_associate`, `prob_bachelor`: Class probabilities
-
-### 5. Course Success Model
-
-**Algorithm**: Random Forest Regressor
-**Target**: Continuous (GPA 0-4 scale)
-
-**Output**:
-- `predicted_gpa`: Expected GPA (0-4 scale)
-- `gpa_performance`: Performance vs. expected (Above/Below/As Expected)
-
-## 📊 Data
-
-### Input Files
-
-| File | Description | Records |
-|------|-------------|---------|
-| `ar_bscc_with_zip.csv` | AR data with zip codes | ~4K |
-| `bishop_state_cohorts_with_zip.csv` | Student cohort information | ~4K |
-| `bishop_state_courses.csv` | Course enrollment records | ~100K |
-| `bishop_state_student_level_with_zip.csv` | Aggregated student-level data | ~4K |
-
-### Feature Categories
-
-1. **Demographics**: Age, race, ethnicity, gender, first-generation status
-2. **Academic Preparation**: Math/English/Reading placement levels
-3. **Enrollment**: Type, intensity, attendance status, cohort term
-4. **Course Performance**: Credits, grades, completion rates, gateway courses
-5. **Financial**: Pell grant status
-6. **Geographic**: Zip code information
-
-## 📈 Output
-
-### Database Tables (Primary Output)
-
-Predictions are saved to Postgres (Supabase):
-
-1. **`student_predictions`** (Table)
-   - Student-level data with all predictions
-   - One row per student (~4,000 records)
-
-2. **`course_predictions`** (Table)
-   - Course-level data with predictions
-   - One row per course enrollment (~99,559 records)
-
-3. **`ml_model_performance`** (Table)
-   - Model performance metrics for each training run
-
-### Generated Files (Fallback)
-
-If database connection fails, predictions are saved to CSV:
-
-1. **`bishop_state_student_level_with_predictions.csv`**
-2. **`bishop_state_merged_with_predictions.csv`**
-3. **`ML_PIPELINE_REPORT.txt`**
-
-## 📚 Documentation
-
-- **[DATA_DICTIONARY.md](DATA_DICTIONARY.md)**: Detailed descriptions of all data fields
-- **[ML_MODELS_GUIDE.md](ML_MODELS_GUIDE.md)**: In-depth guide to machine learning models
-- **[DOCKER_SETUP.md](DOCKER_SETUP.md)**: Docker Compose setup for local Postgres
-- **Model Code**: Extensively commented Python scripts in `ai_model/`
-
-## 🔧 Configuration
-
-### Model Parameters
-
-Edit `complete_ml_pipeline.py` to adjust:
-
-- **XGBoost parameters**: `n_estimators`, `max_depth`, `learning_rate`
-- **Random Forest parameters**: `n_estimators`, `max_depth`, `n_jobs`
-- **Train-test split**: `test_size`, `random_state`
-- **Risk thresholds**: Alert levels in `assign_alert_level()`
-
-## 🤝 Contributing
-
-This project was developed for the Bishop State Datathon. Contributions are welcome!
-
-### Development Workflow
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
-
-## 📝 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 👥 Team
-
-**CodeBenders Team**
-Bishop State Datathon 2025
-
-## 🙏 Acknowledgments
-
-- Bishop State Community College
-- Datathon organizers and mentors
-- Open-source ML community (scikit-learn, XGBoost, pandas)
-
-## 📞 Contact
-
-For questions or support, please open an issue on GitHub or contact the team.
 
 ---
 
-**Built with ❤️ for student success**
+## Supabase Setup
+
+### Option A — Hosted Supabase (recommended)
+
+1. Create a project at [supabase.com](https://supabase.com)
+2. Go to **Project Settings → Database → Connection string → URI (pooler)**
+3. Copy the pooler connection string (`aws-0-us-east-1.pooler.supabase.com:6543`)
+
+**`.env` (ML pipeline)**
+
+```env
+DB_HOST=aws-0-us-east-1.pooler.supabase.com
+DB_USER=postgres.<project-ref>
+DB_PASSWORD=<your-password>
+DB_PORT=6543
+DB_NAME=postgres
+DB_SSL=true
+```
+
+**`codebenders-dashboard/.env.local` (dashboard)**
+
+```env
+DB_HOST=aws-0-us-east-1.pooler.supabase.com
+DB_USER=postgres.<project-ref>
+DB_PASSWORD=<your-password>
+DB_PORT=6543
+DB_NAME=postgres
+DB_SSL=true
+
+OPENAI_API_KEY=sk-...
+```
+
+### Option B — Local Supabase
+
+```bash
+# Requires Supabase CLI: https://supabase.com/docs/guides/cli
+supabase start
+
+# Default local credentials (custom ports to avoid conflicts)
+DB_HOST=127.0.0.1
+DB_PORT=54332
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=postgres
+DB_SSL=false
+```
+
+---
+
+## Project Structure
+
+```
+codebenders-datathon/
+├── ai_model/
+│   ├── complete_ml_pipeline.py        # Entry point — trains all 7 models
+│   └── generate_bishop_state_data.py  # Synthetic data generation
+│
+├── codebenders-dashboard/             # Next.js 16 web application
+│   ├── app/                           # App Router pages & API routes
+│   │   ├── page.tsx                   # Dashboard home (KPIs + charts)
+│   │   ├── students/                  # Paginated student roster
+│   │   ├── query/                     # Natural language query interface
+│   │   ├── methodology/               # Model explainability page
+│   │   └── api/dashboard/             # kpis / risk-alerts / retention-risk / readiness
+│   └── components/                    # shadcn/ui React components
+│
+├── data/                              # Input CSV files (~4K students, ~500K courses)
+├── operations/                        # DB utilities (psycopg2, connection pool)
+├── docs/
+│   └── demo/DEMO.md                   # 6-minute talk track + screenshot guide
+├── supabase/                          # Supabase local config
+├── DATA_DICTIONARY.md                 # All field definitions
+├── ML_MODELS_GUIDE.md                 # Model details & feature importance
+└── QUICKSTART.md                      # Condensed setup guide
+```
+
+---
+
+## ML Models
+
+| # | Model | Algorithm | Target | Key Output |
+|---|-------|-----------|--------|-----------|
+| 1 | **Retention** | XGBoost Classifier | Retained / Not Retained | `retention_probability`, `retention_risk_category` |
+| 2 | **Early Warning** | Composite Score | URGENT / HIGH / MODERATE / LOW | `at_risk_alert`, `risk_score` |
+| 3 | **Time-to-Credential** | XGBoost Regressor | Years to completion | `predicted_time_to_credential` |
+| 4 | **Credential Type** | Random Forest Classifier | Certificate / Associate / Bachelor | `predicted_credential_label` |
+| 5 | **GPA** | Random Forest Regressor | GPA (0–4) | `predicted_gpa`, `gpa_performance` |
+| 6 | **Gateway Math** | Logistic Regression | Pass gateway math (Y/N) | `gateway_math_probability` |
+| 7 | **Gateway English** | Logistic Regression | Pass gateway English (Y/N) | `gateway_english_probability` |
+
+All predictions write to the `student_level_with_predictions` table in Supabase Postgres.
+
+---
+
+## Dashboard Features
+
+| Page | Description |
+|------|-------------|
+| **/** | Four KPI tiles (retention rate, predicted retention, at-risk count, course completion). Risk alert distribution + retention risk charts. AI readiness assessment. **Filter bar** by cohort, enrollment type, and credential type. |
+| **/students** | Full paginated student roster (50/page). Sortable columns. Multi-filter (alert level, readiness tier, credential type, GUID search). CSV export up to 5,000 rows. |
+| **/query** | Natural language → SQL via OpenAI. Renders results as charts or tables. Prompt history with re-run and CSV audit log export. |
+| **/methodology** | Readiness score formula, worked examples, model accuracy metrics. |
+
+---
+
+## Database Schema
+
+Two main tables written by the ML pipeline:
+
+**`student_level_with_predictions`** (~4,000 rows)
+
+| Column | Description |
+|--------|-------------|
+| `Student_GUID` | Anonymised student identifier |
+| `Cohort` | Entry year (e.g. `2022-23`) |
+| `Enrollment_Intensity_First_Term` | `Full-Time` \| `Part-Time` |
+| `retention_probability` | Probability of returning (0–1) |
+| `at_risk_alert` | `URGENT` \| `HIGH` \| `MODERATE` \| `LOW` |
+| `gateway_math_probability` | Probability of passing gateway math (0–1) |
+| `gateway_english_probability` | Probability of passing gateway English (0–1) |
+| `low_gpa_probability` | Probability of GPA < 2.0 (0–1) |
+| `predicted_time_to_credential` | Years to credential |
+| `predicted_credential_label` | `Certificate` \| `Associate` \| `Bachelor` |
+
+**`llm_recommendations`** (~4,000 rows)
+AI-generated readiness scores, risk factors, and suggested interventions per student.
+
+---
+
+## Tech Stack
+
+| Layer | Technologies |
+|-------|-------------|
+| ML Pipeline | Python 3.8+, XGBoost, scikit-learn, pandas, psycopg2 |
+| Frontend | Next.js 16, React 19, TypeScript, Tailwind CSS |
+| Charts | Recharts |
+| UI Components | shadcn/ui (Radix UI) |
+| Database | Supabase Postgres (pg driver) |
+| AI Features | OpenAI (natural language → SQL) |
+| Deployment | Vercel (dashboard), Supabase cloud (DB) |
+
+---
+
+## Documentation
+
+| Topic | File |
+|-------|------|
+| 6-minute demo talk track | [docs/demo/DEMO.md](docs/demo/DEMO.md) |
+| Screenshot capture guide | [docs/demo/screenshots/README.md](docs/demo/screenshots/README.md) |
+| All data field definitions | [DATA_DICTIONARY.md](DATA_DICTIONARY.md) |
+| ML model details & accuracy | [ML_MODELS_GUIDE.md](ML_MODELS_GUIDE.md) |
+| Dashboard feature guide | [codebenders-dashboard/DASHBOARD_README.md](codebenders-dashboard/DASHBOARD_README.md) |
+| DB utilities | [operations/README.md](operations/README.md) |
+| Condensed setup | [QUICKSTART.md](QUICKSTART.md) |
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+---
+
+*Built by the CodeBenders team for the Bishop State Datathon 2025.*


### PR DESCRIPTION
## Summary

- **Architecture diagram** (ASCII) showing the full stack: CSV data → ML pipeline → Supabase Postgres → Next.js dashboard → Vercel
- **3-step quick start** with copy-paste commands for ML pipeline (`venv`, `pip install`, `python complete_ml_pipeline.py`) and dashboard (`npm install`, `npm run dev`)
- **Supabase setup section** with two options: hosted (pooler connection string with exact `.env` block) and local CLI
- **7-model ML table** — was outdated at 5 models, now includes Gateway Math and Gateway English (Logistic Regression)
- **Correct table names** — `student_level_with_predictions` and `llm_recommendations` (old README referenced `student_predictions`/`course_predictions`)
- **Dashboard feature table** covering all 4 pages (`/`, `/students`, `/query`, `/methodology`)
- **Link to `docs/demo/DEMO.md`** for the 6-minute demo talk track
- QUICKSTART.md condensed to 3 steps + key output columns table

## Test plan

- [ ] Read README cold — can a new contributor set up the project with zero prior knowledge?
- [ ] Verify all internal links resolve (`DATA_DICTIONARY.md`, `ML_MODELS_GUIDE.md`, `docs/demo/DEMO.md`, etc.)
- [ ] Copy-paste the `.env` block and confirm the ML pipeline connects

Closes #21