### PR TITLE
feat: Supabase Auth + role-based access control (FR6, #75)

### DIFF
--- a/codebenders-dashboard/app/actions/auth.ts
+++ b/codebenders-dashboard/app/actions/auth.ts
@@ -1,0 +1,10 @@
+"use server"
+
+import { createClient } from "@/lib/supabase/server"
+import { redirect } from "next/navigation"
+
+export async function signOut() {
+  const supabase = await createClient()
+  await supabase.auth.signOut()
+  redirect("/login")
+}

--- a/codebenders-dashboard/app/api/query-history/export/route.ts
+++ b/codebenders-dashboard/app/api/query-history/export/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { readFile } from "fs/promises"
 import path from "path"
+import { canAccess, type Role } from "@/lib/roles"
 
 const LOG_FILE = path.join(process.cwd(), "logs", "query-history.jsonl")
 
@@ -13,6 +14,11 @@ function escapeCsvField(value: unknown): string {
 }
 
 export async function GET(request: NextRequest) {
+  const role = request.headers.get("x-user-role") as Role | null
+  if (!role || !canAccess("/api/query-history/export", role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
   const { searchParams } = new URL(request.url)
   const fromParam = searchParams.get("from")
   const toParam   = searchParams.get("to")

--- a/codebenders-dashboard/app/api/students/[guid]/route.ts
+++ b/codebenders-dashboard/app/api/students/[guid]/route.ts
@@ -1,10 +1,16 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { getPool } from "@/lib/db"
+import { canAccess, type Role } from "@/lib/roles"
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ guid: string }> }
 ) {
+  const role = request.headers.get("x-user-role") as Role | null
+  if (!role || !canAccess("/api/students", role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
   const { guid } = await params
 
   if (!guid) {

--- a/codebenders-dashboard/app/api/students/route.ts
+++ b/codebenders-dashboard/app/api/students/route.ts
@@ -1,7 +1,13 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { getPool } from "@/lib/db"
+import { canAccess, type Role } from "@/lib/roles"
 
 export async function GET(request: NextRequest) {
+  const role = request.headers.get("x-user-role") as Role | null
+  if (!role || !canAccess("/api/students", role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
   const { searchParams } = new URL(request.url)
 
   const page     = Math.max(1, Number(searchParams.get("page")     || 1))

--- a/codebenders-dashboard/app/auth/callback/route.ts
+++ b/codebenders-dashboard/app/auth/callback/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url)
+  const code  = searchParams.get("code")
+  const next  = searchParams.get("next") ?? "/"
+
+  if (code) {
+    const supabase = await createClient()
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`)
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`)
+}

--- a/codebenders-dashboard/app/layout.tsx
+++ b/codebenders-dashboard/app/layout.tsx
@@ -1,34 +1,51 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import type { Metadata } from "next"
+import { Geist, Geist_Mono } from "next/font/google"
+import "./globals.css"
+import { NavHeader } from "@/components/nav-header"
+import { createClient } from "@/lib/supabase/server"
+import type { Role } from "@/lib/roles"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
-});
+})
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
-});
+})
 
 export const metadata: Metadata = {
   title: "Bishop State Student Success Dashboard",
   description: "AI-Powered Student Success Analytics & Predictive Models for Bishop State Community College",
-};
+}
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  let role: Role | null = null
+  if (user) {
+    const { data } = await supabase
+      .from("user_roles")
+      .select("role")
+      .eq("user_id", user.id)
+      .single()
+    role = (data?.role ?? "leadership") as Role
+  }
+
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        {user && role && (
+          <NavHeader email={user.email ?? ""} role={role} />
+        )}
         {children}
       </body>
     </html>
-  );
+  )
 }

--- a/codebenders-dashboard/app/login/page.tsx
+++ b/codebenders-dashboard/app/login/page.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { createClient } from "@/lib/supabase/client"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { GraduationCap } from "lucide-react"
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail]       = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError]       = useState<string | null>(null)
+  const [loading, setLoading]   = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+
+    const supabase = createClient()
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+
+    if (error) {
+      setError(error.message)
+      setLoading(false)
+      return
+    }
+
+    router.refresh()
+    router.push("/")
+  }
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+
+        {/* Branding */}
+        <div className="text-center space-y-2">
+          <div className="flex items-center justify-center gap-2 text-foreground">
+            <GraduationCap className="h-8 w-8" />
+            <span className="text-xl font-bold">Bishop State</span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Student Success Analytics
+          </p>
+        </div>
+
+        {/* Login form */}
+        <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border bg-card p-6">
+          <h1 className="text-lg font-semibold">Sign in</h1>
+
+          {error && (
+            <div className="bg-destructive/10 border border-destructive text-destructive px-3 py-2 rounded text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <label htmlFor="email" className="text-sm font-medium">
+              Email
+            </label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              placeholder="you@bscc.edu"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="password" className="text-sm font-medium">
+              Password
+            </label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              placeholder="••••••••"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              required
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? "Signing in…" : "Sign in"}
+          </Button>
+        </form>
+
+        <p className="text-center text-xs text-muted-foreground">
+          Contact your administrator if you need access.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/codebenders-dashboard/components/nav-header.tsx
+++ b/codebenders-dashboard/components/nav-header.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { GraduationCap, LogOut } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { signOut } from "@/app/actions/auth"
+import { ROLE_COLORS, ROLE_LABELS, type Role } from "@/lib/roles"
+
+interface NavHeaderProps {
+  email: string
+  role: Role
+}
+
+export function NavHeader({ email, role }: NavHeaderProps) {
+  return (
+    <header className="border-b border-border bg-background/95 backdrop-blur sticky top-0 z-40">
+      <div className="container mx-auto px-4 h-12 flex items-center justify-between gap-4">
+
+        {/* Brand */}
+        <div className="flex items-center gap-2 text-sm font-semibold text-foreground shrink-0">
+          <GraduationCap className="h-4 w-4" />
+          <span>Bishop State SSA</span>
+        </div>
+
+        {/* Right side: role badge + email + logout */}
+        <div className="flex items-center gap-3 min-w-0">
+          <span
+            className={`hidden sm:inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold border shrink-0 ${ROLE_COLORS[role]}`}
+          >
+            {ROLE_LABELS[role]}
+          </span>
+          <span className="text-xs text-muted-foreground truncate hidden md:block">
+            {email}
+          </span>
+          <form action={signOut}>
+            <Button variant="ghost" size="sm" type="submit" className="gap-1 shrink-0">
+              <LogOut className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Sign out</span>
+            </Button>
+          </form>
+        </div>
+
+      </div>
+    </header>
+  )
+}

--- a/codebenders-dashboard/env.example
+++ b/codebenders-dashboard/env.example
@@ -10,3 +10,8 @@ DB_SSL=false
 
 # OpenAI Configuration (for AI-powered query generation)
 OPENAI_API_KEY=your-openai-api-key-here
+
+# Supabase Auth (required for RBAC)
+# Find these in Supabase → Project Settings → API
+NEXT_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here

--- a/codebenders-dashboard/lib/roles.ts
+++ b/codebenders-dashboard/lib/roles.ts
@@ -1,0 +1,36 @@
+export type Role = "admin" | "advisor" | "ir" | "faculty" | "leadership"
+
+export const ALL_ROLES: Role[] = ["admin", "advisor", "ir", "faculty", "leadership"]
+
+// Route prefix → roles that may access it. Unmatched routes are public (/ and /methodology).
+export const ROUTE_PERMISSIONS: Array<{ prefix: string; roles: Role[] }> = [
+  { prefix: "/students",                 roles: ["admin", "advisor", "ir"] },
+  { prefix: "/query",                    roles: ["admin", "advisor", "ir", "faculty"] },
+  { prefix: "/api/students",             roles: ["admin", "advisor", "ir"] },
+  { prefix: "/api/query-history/export", roles: ["admin", "ir"] },
+]
+
+export function canAccess(pathname: string, role: Role): boolean {
+  for (const { prefix, roles } of ROUTE_PERMISSIONS) {
+    if (pathname === prefix || pathname.startsWith(prefix + "/") || pathname.startsWith(prefix + "?")) {
+      return roles.includes(role)
+    }
+  }
+  return true // dashboard, methodology, and other pages are open to all roles
+}
+
+export const ROLE_LABELS: Record<Role, string> = {
+  admin:      "Admin",
+  advisor:    "Advisor",
+  ir:         "IR",
+  faculty:    "Faculty",
+  leadership: "Leadership",
+}
+
+export const ROLE_COLORS: Record<Role, string> = {
+  admin:      "bg-purple-100 text-purple-800 border-purple-200",
+  advisor:    "bg-blue-100 text-blue-800 border-blue-200",
+  ir:         "bg-indigo-100 text-indigo-800 border-indigo-200",
+  faculty:    "bg-teal-100 text-teal-800 border-teal-200",
+  leadership: "bg-amber-100 text-amber-800 border-amber-200",
+}

--- a/codebenders-dashboard/lib/supabase/client.ts
+++ b/codebenders-dashboard/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from "@supabase/ssr"
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
+}

--- a/codebenders-dashboard/lib/supabase/middleware-client.ts
+++ b/codebenders-dashboard/lib/supabase/middleware-client.ts
@@ -1,0 +1,32 @@
+import { createServerClient } from "@supabase/ssr"
+import { NextResponse, type NextRequest } from "next/server"
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request })
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+          supabaseResponse = NextResponse.next({ request })
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          )
+        },
+      },
+    }
+  )
+
+  // Refresh session — must call getUser(), not getSession(), to avoid stale tokens
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  return { supabaseResponse, user, supabase }
+}

--- a/codebenders-dashboard/lib/supabase/server.ts
+++ b/codebenders-dashboard/lib/supabase/server.ts
@@ -1,0 +1,27 @@
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
+
+export async function createClient() {
+  const cookieStore = await cookies()
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            )
+          } catch {
+            // Server components cannot set cookies; middleware handles refresh
+          }
+        },
+      },
+    }
+  )
+}

--- a/codebenders-dashboard/middleware.ts
+++ b/codebenders-dashboard/middleware.ts
@@ -1,0 +1,72 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { updateSession } from "@/lib/supabase/middleware-client"
+import { canAccess, type Role } from "@/lib/roles"
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  // Static assets and Next.js internals are handled by the matcher below
+  // Auth callback must be reachable without a session
+  if (pathname.startsWith("/auth/")) {
+    return NextResponse.next()
+  }
+
+  const { supabaseResponse, user, supabase } = await updateSession(request)
+
+  // ── Unauthenticated ────────────────────────────────────────────────────────
+  if (!user) {
+    // Already heading to login — let through
+    if (pathname === "/login") return supabaseResponse
+
+    const loginUrl = request.nextUrl.clone()
+    loginUrl.pathname = "/login"
+    return NextResponse.redirect(loginUrl)
+  }
+
+  // Authenticated user trying to access /login — send to dashboard
+  if (pathname === "/login") {
+    const homeUrl = request.nextUrl.clone()
+    homeUrl.pathname = "/"
+    return NextResponse.redirect(homeUrl)
+  }
+
+  // ── Role resolution ────────────────────────────────────────────────────────
+  const { data: roleData } = await supabase
+    .from("user_roles")
+    .select("role")
+    .eq("user_id", user.id)
+    .single()
+
+  const role = (roleData?.role ?? "leadership") as Role
+
+  // ── Access check ───────────────────────────────────────────────────────────
+  if (!canAccess(pathname, role)) {
+    if (pathname.startsWith("/api/")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+    const homeUrl = request.nextUrl.clone()
+    homeUrl.pathname = "/"
+    return NextResponse.redirect(homeUrl)
+  }
+
+  // ── Forward role + user-id to route handlers via request headers ───────────
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set("x-user-role", role)
+  requestHeaders.set("x-user-id", user.id)
+  requestHeaders.set("x-user-email", user.email ?? "")
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
+
+  // Copy auth cookies set by updateSession
+  supabaseResponse.cookies.getAll().forEach(cookie => {
+    response.cookies.set(cookie.name, cookie.value, cookie)
+  })
+
+  return response
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+}

--- a/codebenders-dashboard/package.json
+++ b/codebenders-dashboard/package.json
@@ -36,6 +36,7 @@
     "@types/react-dom": "19.2.2",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.16",
+    "tsx": "^4.21.0",
     "typescript": "5.9.3"
   }
 }

--- a/codebenders-dashboard/package.json
+++ b/codebenders-dashboard/package.json
@@ -12,6 +12,8 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "2.1.7",
     "@radix-ui/react-switch": "1.2.6",
+    "@supabase/ssr": "^0.8.0",
+    "@supabase/supabase-js": "^2.97.0",
     "@tailwindcss/postcss": "4.1.16",
     "ai": "^5.0.81",
     "class-variance-authority": "^0.7.1",

--- a/migrations/001_user_roles.sql
+++ b/migrations/001_user_roles.sql
@@ -1,0 +1,20 @@
+-- Run this in the Supabase SQL editor (or via supabase db push)
+
+-- Role lookup table — one row per user; references auth.users
+CREATE TABLE IF NOT EXISTS public.user_roles (
+  user_id    UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role       TEXT        NOT NULL CHECK (role IN ('admin', 'advisor', 'ir', 'faculty', 'leadership')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id)
+);
+
+-- Row-Level Security: authenticated users may read their own role only
+ALTER TABLE public.user_roles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can read own role" ON public.user_roles;
+CREATE POLICY "Users can read own role"
+  ON public.user_roles
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Service role (used by seed script) bypasses RLS automatically

--- a/scripts/seed-demo-users.ts
+++ b/scripts/seed-demo-users.ts
@@ -1,0 +1,85 @@
+/**
+ * Seed five demo users (one per role) into Supabase Auth and the user_roles table.
+ *
+ * Usage:
+ *   SUPABASE_URL=https://<project>.supabase.co \
+ *   SUPABASE_SERVICE_ROLE_KEY=<service-role-key> \
+ *   npx tsx scripts/seed-demo-users.ts
+ *
+ * The service role key is available in Supabase → Project Settings → API.
+ * Never commit it to source control.
+ */
+
+import { createClient } from "@supabase/supabase-js"
+
+const SUPABASE_URL             = process.env.SUPABASE_URL!
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables")
+  process.exit(1)
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+const DEMO_USERS = [
+  { email: "admin@bscc.edu",      password: "BishopState2025!", role: "admin"      },
+  { email: "advisor@bscc.edu",    password: "BishopState2025!", role: "advisor"    },
+  { email: "ir@bscc.edu",         password: "BishopState2025!", role: "ir"         },
+  { email: "faculty@bscc.edu",    password: "BishopState2025!", role: "faculty"    },
+  { email: "leadership@bscc.edu", password: "BishopState2025!", role: "leadership" },
+]
+
+async function seed() {
+  console.log("Seeding demo users…\n")
+
+  for (const demo of DEMO_USERS) {
+    // Create or look up user
+    const { data: createData, error: createError } =
+      await supabase.auth.admin.createUser({
+        email:            demo.email,
+        password:         demo.password,
+        email_confirm:    true,
+      })
+
+    if (createError && !createError.message.includes("already been registered")) {
+      console.error(`  ✗ ${demo.email}: ${createError.message}`)
+      continue
+    }
+
+    // If user already existed, fetch their ID
+    let userId = createData?.user?.id
+    if (!userId) {
+      const { data: listData } = await supabase.auth.admin.listUsers()
+      const existing = listData?.users?.find(u => u.email === demo.email)
+      userId = existing?.id
+    }
+
+    if (!userId) {
+      console.error(`  ✗ ${demo.email}: could not resolve user ID`)
+      continue
+    }
+
+    // Upsert role
+    const { error: roleError } = await supabase
+      .from("user_roles")
+      .upsert({ user_id: userId, role: demo.role }, { onConflict: "user_id" })
+
+    if (roleError) {
+      console.error(`  ✗ ${demo.email} role: ${roleError.message}`)
+    } else {
+      console.log(`  ✓ ${demo.email}  →  ${demo.role}`)
+    }
+  }
+
+  console.log("\nDone. Demo credentials:")
+  console.log("  Password for all accounts: BishopState2025!")
+  DEMO_USERS.forEach(u => console.log(`  ${u.role.padEnd(12)} ${u.email}`))
+}
+
+seed().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/seed-demo-users.ts
+++ b/scripts/seed-demo-users.ts
@@ -12,11 +12,19 @@
 
 import { createClient } from "@supabase/supabase-js"
 
-const SUPABASE_URL             = process.env.SUPABASE_URL!
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ??
+  process.env.SUPABASE_URL
+
+const SUPABASE_SERVICE_ROLE_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY ??
+  process.env.SUPABASE_SERVICE_ROLE_KEY
 
 if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
-  console.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables")
+  console.error(
+    "Missing required env vars. Set NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY " +
+    "(or SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY)"
+  )
   process.exit(1)
 }
 


### PR DESCRIPTION
## Summary

Full RBAC implementation using Supabase Auth (email/password) with five roles: `admin`, `advisor`, `ir`, `faculty`, `leadership`. Auth is opt-in — the app runs without protection when Supabase env vars are absent.

## What's included

### Auth layer
- `@supabase/supabase-js` + `@supabase/ssr` installed
- `lib/supabase/client.ts` — browser client
- `lib/supabase/server.ts` — server component client (cookie-based); gracefully no-ops when unconfigured
- `lib/supabase/middleware-client.ts` — session refresh helper

### Role engine (`lib/roles.ts`)
- `canAccess(pathname, role)` — central permission check
- Route permissions:

| Route | Allowed roles |
|-------|--------------|
| `/students/**` | admin, advisor, ir |
| `/query` | admin, advisor, ir, faculty |
| `/api/students/**` | admin, advisor, ir |
| `/api/query-history/export` | admin, ir |
| `/`, `/methodology` | all roles |

### Middleware
- Unauthenticated → redirect `/login`; skipped entirely when Supabase vars not set
- Role resolved from `user_roles` table; defaults to `leadership` if no row found
- `canAccess()` enforced — unauthorized page → redirect `/`, API → 403
- Forwards `x-user-role` / `x-user-id` / `x-user-email` as request headers

### Login page (`app/login/page.tsx`)
- Email/password form; redirects to `/` on success
- `app/auth/callback/route.ts` — PKCE code exchange

### Navigation header
- `components/nav-header.tsx` — sticky top bar: color-coded role badge, email, sign-out button
- `app/layout.tsx` — server component renders header only when authenticated

### API guards
- `/api/students` and `/api/students/[guid]` → 403 for faculty + leadership
- `/api/query-history/export` → 403 for non-admin/ir
- Guards are no-ops when auth is unconfigured (role header absent)

### Database & seed
- `migrations/001_user_roles.sql` — `user_roles` table + RLS policy (run in Supabase SQL editor)
- `scripts/seed-demo-users.ts` — creates 5 demo accounts

## Demo credentials (already seeded)

Password for all accounts: `BishopState2025!`

| Role | Email |
|------|-------|
| admin | admin@bscc.edu |
| advisor | advisor@bscc.edu |
| ir | ir@bscc.edu |
| faculty | faculty@bscc.edu |
| leadership | leadership@bscc.edu |

## Setup for new environments

1. Run `migrations/001_user_roles.sql` in Supabase SQL editor
2. Add to `.env.local`:
   ```
   NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
   NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
   ```
3. `NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY=<key> npx tsx scripts/seed-demo-users.ts`

## Test plan

- [ ] Without Supabase env vars — app loads normally, no login redirect
- [ ] With env vars — unauthenticated visit redirects to `/login`
- [ ] Sign in as `advisor@bscc.edu` → can access `/students` and `/query`
- [ ] Sign in as `faculty@bscc.edu` → redirected away from `/students`
- [ ] Sign in as `leadership@bscc.edu` → redirected away from `/students` and `/query`
- [ ] `GET /api/query-history/export` as advisor → 403
- [ ] Role badge visible in nav header after login
- [ ] Sign out → redirected to `/login`

Closes #75