### PR TITLE
feat: NQL interface redesign — nav link, sidebar history, LLM Summarize (#88)

### DIFF
--- a/codebenders-dashboard/app/api/query-summary/route.ts
+++ b/codebenders-dashboard/app/api/query-summary/route.ts
@@ -15,7 +15,20 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "OpenAI API key not configured" }, { status: 500 })
   }
 
-  const { prompt, data, rowCount, vizType } = await request.json()
+  let prompt: string
+  let data: unknown[]
+  let rowCount: number
+  let vizType: string
+
+  try {
+    const body = await request.json()
+    prompt = body.prompt
+    data = body.data
+    rowCount = body.rowCount ?? 0
+    vizType = body.vizType ?? "unknown"
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
 
   if (!prompt || !Array.isArray(data)) {
     return NextResponse.json({ error: "prompt and data are required" }, { status: 400 })
@@ -26,7 +39,7 @@ export async function POST(request: NextRequest) {
 
   const llmPrompt = `You are a student success analyst at a community college. An advisor ran the following query and got these results.
 
-QUERY: "${prompt}"
+QUERY: "${prompt.slice(0, 2000)}"
 RESULT: ${rowCount} rows, visualization type: ${vizType}
 DATA SAMPLE:
 ${JSON.stringify(sampleRows, null, 2)}

--- a/codebenders-dashboard/app/api/query-summary/route.ts
+++ b/codebenders-dashboard/app/api/query-summary/route.ts
@@ -1,0 +1,50 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { canAccess, type Role } from "@/lib/roles"
+import { generateText } from "ai"
+import { createOpenAI } from "@ai-sdk/openai"
+
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY || "" })
+
+export async function POST(request: NextRequest) {
+  const role = request.headers.get("x-user-role") as Role | null
+  if (!role || !canAccess("/api/query-summary", role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return NextResponse.json({ error: "OpenAI API key not configured" }, { status: 500 })
+  }
+
+  const { prompt, data, rowCount, vizType } = await request.json()
+
+  if (!prompt || !Array.isArray(data)) {
+    return NextResponse.json({ error: "prompt and data are required" }, { status: 400 })
+  }
+
+  // Cap rows sent to LLM to avoid token overflow
+  const sampleRows = data.slice(0, 50)
+
+  const llmPrompt = `You are a student success analyst at a community college. An advisor ran the following query and got these results.
+
+QUERY: "${prompt}"
+RESULT: ${rowCount} rows, visualization type: ${vizType}
+DATA SAMPLE:
+${JSON.stringify(sampleRows, null, 2)}
+
+Write a 2-3 sentence plain-English summary of what these results show. Be specific about the numbers. Do not speculate beyond the data. Address the advisor directly.`
+
+  try {
+    const result = await generateText({
+      model: openai("gpt-4o-mini"),
+      prompt: llmPrompt,
+      maxOutputTokens: 200,
+    })
+    return NextResponse.json({ summary: result.text })
+  } catch (error) {
+    console.error("[query-summary] Error:", error)
+    return NextResponse.json(
+      { error: "Failed to generate summary", details: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    )
+  }
+}

--- a/codebenders-dashboard/app/query/page.tsx
+++ b/codebenders-dashboard/app/query/page.tsx
@@ -1,9 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
 import { Label } from "@/components/ui/label"
@@ -13,8 +11,7 @@ import { QueryHistoryPanel } from "@/components/query-history-panel"
 import { analyzePrompt } from "@/lib/prompt-analyzer"
 import { executeQuery } from "@/lib/query-executor"
 import type { QueryPlan, QueryResult, HistoryEntry } from "@/lib/types"
-import Link from "next/link"
-import { ArrowLeft } from "lucide-react"
+import { Loader2, Sparkles, PanelLeft } from "lucide-react"
 
 const INSTITUTIONS = [
   { name: "Bishop State", code: "bscc" },
@@ -30,6 +27,10 @@ export default function QueryPage() {
   const [queryPlan, setQueryPlan] = useState<QueryPlan | null>(null)
   const [queryResult, setQueryResult] = useState<QueryResult | null>(null)
   const [useDirectDB, setUseDirectDB] = useState(true)
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [summary, setSummary] = useState<string | null>(null)
+  const [summaryLoading, setSummaryLoading] = useState(false)
+  const [summaryError, setSummaryError] = useState<string | null>(null)
   const [history, setHistory] = useState<HistoryEntry[]>(() => {
     // Read from localStorage on mount (client-only)
     if (typeof window === "undefined") return []
@@ -44,6 +45,9 @@ export default function QueryPage() {
     overridePrompt?: string,
     overrideInstitution?: string,
   ) => {
+    setSummary(null)
+    setSummaryError(null)
+
     const activePrompt = overridePrompt ?? prompt
     const activeInstitution = overrideInstitution ?? institution
 
@@ -125,100 +129,205 @@ export default function QueryPage() {
     localStorage.removeItem("bishop_query_history")
   }
 
+  const handleSummarize = async () => {
+    if (!queryResult || !queryPlan) return
+    setSummaryLoading(true)
+    setSummaryError(null)
+    try {
+      const res = await fetch("/api/query-summary", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt,
+          data: queryResult.data,
+          rowCount: queryResult.rowCount,
+          vizType: queryPlan.vizType,
+        }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || "Failed")
+      setSummary(json.summary)
+    } catch (e) {
+      setSummaryError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSummaryLoading(false)
+    }
+  }
+
   return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto p-6 space-y-6">
-        <div className="border-b border-border pb-6">
-          <Link href="/" className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4">
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            Back to Dashboard
-          </Link>
-          <h1 className="text-3xl font-bold tracking-tight text-foreground">SQL Query Interface</h1>
-          <p className="text-muted-foreground mt-2">Analyze student performance data with natural language queries</p>
-        </div>
+    <div className="min-h-screen bg-background flex flex-col">
+      {/* Slim page-level header bar */}
+      <header className="h-12 flex items-center gap-3 px-4 border-b border-border/60 shrink-0">
+        {/* Mobile sidebar toggle */}
+        <button
+          onClick={() => setSidebarOpen(true)}
+          className="md:hidden p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+          aria-label="Open query history"
+        >
+          <PanelLeft className="h-4 w-4" />
+        </button>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Query Controls</CardTitle>
-            <CardDescription>Select an institution and enter your analysis prompt</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center space-x-2 pb-4 border-b border-border">
-              <Switch id="db-mode" checked={useDirectDB} onCheckedChange={setUseDirectDB} />
-              <Label htmlFor="db-mode" className="text-sm font-medium">
-                {useDirectDB ? "Direct Database" : "API Mode"}
-              </Label>
-              <span className="text-xs text-muted-foreground">
-                {useDirectDB ? "(Execute SQL directly)" : "(Fetch from API endpoints)"}
-              </span>
-            </div>
+        {/* Title group */}
+        <span className="text-sm font-semibold tracking-widest uppercase text-foreground">
+          Query Interface
+        </span>
+        <span className="hidden sm:block h-4 w-px bg-border/60" aria-hidden="true" />
+        <span className="hidden sm:block text-xs text-muted-foreground font-mono">
+          Natural Language Analytics
+        </span>
+      </header>
 
-            <div className="grid gap-4 md:grid-cols-[200px_1fr_auto]">
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Institution</label>
-                <Select value={institution} onValueChange={setInstitution}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {INSTITUTIONS.map((inst) => (
-                      <SelectItem key={inst.code} value={inst.code}>
-                        {inst.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+      {/* Body: sidebar + main */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Desktop sidebar */}
+        <aside className="hidden md:flex w-[260px] border-r border-border/60 flex-col shrink-0 bg-muted/20">
+          <QueryHistoryPanel entries={history} onRerun={handleRerun} onClear={handleClear} />
+        </aside>
 
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-foreground">Analysis Prompt</label>
-                <Input
-                  placeholder="e.g., retention by cohort for last two terms"
-                  value={prompt}
-                  onChange={(e) => setPrompt(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault()
-                      handleAnalyze()
-                    }
-                  }}
-                />
-              </div>
-
-              <div className="flex items-end">
-                <Button onClick={() => handleAnalyze()} disabled={isAnalyzing || !prompt.trim()} className="w-full md:w-auto">
-                  {isAnalyzing ? "Analyzing..." : "Analyze"}
-                </Button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {history.length > 0 && (
-          <QueryHistoryPanel
-            entries={history}
-            onRerun={handleRerun}
-            onClear={handleClear}
-          />
-        )}
-
-        {queryResult && queryPlan && (
-          <div className="grid gap-6 lg:grid-cols-[1fr_400px]">
-            <AnalysisResult result={queryResult} plan={queryPlan} />
-            <QueryPlanPanel plan={queryPlan} />
+        {/* Mobile sidebar overlay */}
+        {sidebarOpen && (
+          <div className="fixed inset-0 z-50 md:hidden">
+            <div
+              className="absolute inset-0 bg-background/80 backdrop-blur-sm"
+              onClick={() => setSidebarOpen(false)}
+            />
+            <aside className="absolute left-0 top-0 bottom-0 w-[260px] bg-background border-r border-border/60 flex flex-col">
+              <QueryHistoryPanel entries={history} onRerun={handleRerun} onClear={handleClear} />
+            </aside>
           </div>
         )}
 
-        {!queryResult && (
-          <Card className="border-dashed">
-            <CardContent className="flex items-center justify-center py-12">
-              <div className="text-center space-y-2">
-                <p className="text-muted-foreground">Enter a prompt and click Analyze to see results</p>
-                <p className="text-sm text-muted-foreground">Try: "Show me all cohorts" or "Count students by term"</p>
+        {/* Main content */}
+        <main className="flex-1 overflow-auto p-6 space-y-6">
+          {/* Query controls */}
+          <div className="border border-border/60 rounded-lg p-5 space-y-4">
+            {/* DB mode toggle row */}
+            <div className="flex items-center gap-3 pb-4 border-b border-border/40">
+              <Switch id="db-mode" checked={useDirectDB} onCheckedChange={setUseDirectDB} />
+              <Label htmlFor="db-mode" className="text-sm font-medium cursor-pointer">
+                {useDirectDB ? "Direct Database" : "API Mode"}
+              </Label>
+              <span className="text-xs text-muted-foreground font-mono">
+                {useDirectDB ? "(execute SQL directly)" : "(fetch from API endpoints)"}
+              </span>
+            </div>
+
+            {/* Institution selector */}
+            <div className="space-y-1.5">
+              <label className="text-[10px] font-semibold tracking-widest uppercase text-muted-foreground/70">
+                Institution
+              </label>
+              <Select value={institution} onValueChange={setInstitution}>
+                <SelectTrigger className="border-border/60 bg-background text-sm w-full md:w-[220px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {INSTITUTIONS.map((inst) => (
+                    <SelectItem key={inst.code} value={inst.code}>
+                      {inst.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Query textarea */}
+            <div className="space-y-1.5">
+              <label className="text-[10px] font-semibold tracking-widest uppercase text-muted-foreground/70">
+                Natural Language Query
+              </label>
+              <textarea
+                placeholder="e.g., retention by cohort for last two terms"
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault()
+                    handleAnalyze()
+                  }
+                }}
+                className="flex w-full rounded-md border border-border/60 bg-muted/20 px-3 py-2 font-mono text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 min-h-[80px] resize-none"
+              />
+            </div>
+
+            {/* Run button row */}
+            <div className="flex justify-end">
+              <Button
+                onClick={() => handleAnalyze()}
+                disabled={isAnalyzing || !prompt.trim()}
+                className="bg-foreground text-background hover:bg-foreground/90 text-xs font-semibold tracking-wide uppercase px-5"
+              >
+                {isAnalyzing ? (
+                  <>
+                    <Loader2 className="h-3 w-3 animate-spin mr-1.5" />
+                    Analyzing…
+                  </>
+                ) : (
+                  "Run Analysis"
+                )}
+              </Button>
+            </div>
+          </div>
+
+          {/* Empty state */}
+          {!queryResult && (
+            <div className="border border-dashed border-border/50 rounded-lg py-12 flex items-center justify-center">
+              <div className="text-center space-y-1.5">
+                <p className="text-sm text-muted-foreground">Enter a query above and run analysis to see results</p>
+                <p className="text-xs text-muted-foreground font-mono">
+                  Try: &ldquo;Show me all cohorts&rdquo; or &ldquo;Count students by term&rdquo;
+                </p>
               </div>
-            </CardContent>
-          </Card>
-        )}
+            </div>
+          )}
+
+          {/* Results section */}
+          {queryResult && queryPlan && (
+            <div className="space-y-3">
+              {/* Results header row */}
+              <div className="flex items-center justify-between">
+                <h2 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">
+                  Results
+                </h2>
+                {!summary && (
+                  <button
+                    onClick={handleSummarize}
+                    disabled={summaryLoading}
+                    className="inline-flex items-center gap-1.5 text-xs font-medium text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 disabled:opacity-50 transition-colors"
+                  >
+                    {summaryLoading ? (
+                      <>
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        Generating…
+                      </>
+                    ) : (
+                      <>
+                        <Sparkles className="h-3 w-3" />
+                        Summarize
+                      </>
+                    )}
+                  </button>
+                )}
+              </div>
+
+              {/* AI summary block */}
+              {summary && (
+                <div className="flex gap-2 px-4 py-3 rounded-lg bg-amber-50/50 dark:bg-amber-950/20 border border-amber-200/60 dark:border-amber-800/40">
+                  <Sparkles className="h-4 w-4 text-amber-500/70 mt-0.5 shrink-0" />
+                  <p className="text-sm text-foreground/90 leading-relaxed">{summary}</p>
+                </div>
+              )}
+              {summaryError && (
+                <p className="text-xs text-destructive">{summaryError}</p>
+              )}
+
+              <div className="grid gap-6 lg:grid-cols-[1fr_400px]">
+                <AnalysisResult result={queryResult} plan={queryPlan} />
+                <QueryPlanPanel plan={queryPlan} />
+              </div>
+            </div>
+          )}
+        </main>
       </div>
     </div>
   )

--- a/codebenders-dashboard/components/nav-header.tsx
+++ b/codebenders-dashboard/components/nav-header.tsx
@@ -16,6 +16,7 @@ const NAV_LINKS = [
   { href: "/",          label: "Dashboard" },
   { href: "/courses",   label: "Courses"   },
   { href: "/students",  label: "Students"  },
+  { href: "/query",     label: "Query"     },
 ]
 
 export function NavHeader({ email, role }: NavHeaderProps) {

--- a/codebenders-dashboard/components/query-history-panel.tsx
+++ b/codebenders-dashboard/components/query-history-panel.tsx
@@ -1,9 +1,5 @@
 "use client"
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Download } from "lucide-react"
 import type { HistoryEntry } from "@/lib/types"
 
 function relativeTime(isoTimestamp: string): string {
@@ -40,72 +36,70 @@ interface QueryHistoryPanelProps {
 
 export function QueryHistoryPanel({ entries, onRerun, onClear }: QueryHistoryPanelProps) {
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <CardTitle className="text-base font-semibold">Recent Queries</CardTitle>
-        <div className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="gap-1"
-            asChild
-          >
-            <a href="/api/query-history/export" download="query-audit-log.csv">
-              <Download className="h-3 w-3" />
-              Export
-            </a>
-          </Button>
-          <Button variant="ghost" size="sm" onClick={onClear}>
-            Clear
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent className="p-0">
-        <ul className="divide-y divide-border">
-          {/* Entries arrive pre-sorted: newest first from page.tsx */}
-          {entries.map((entry) => {
-            const truncated =
-              entry.prompt.length > 60
-                ? entry.prompt.slice(0, 60) + "…"
-                : entry.prompt
+    <div className="flex flex-col h-full">
+      {/* Sidebar header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+        <span className="text-sm font-semibold">Recent Queries</span>
+        <a
+          href="/api/query-history/export"
+          download="query-audit-log.csv"
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Export
+        </a>
+      </div>
+
+      {/* Scrollable list */}
+      <ul className="flex-1 overflow-y-auto divide-y divide-border">
+        {entries.length === 0 ? (
+          <li className="px-4 py-6 text-xs text-muted-foreground text-center">
+            No queries yet
+          </li>
+        ) : (
+          entries.map((entry) => {
+            const truncated = entry.prompt.length > 55
+              ? entry.prompt.slice(0, 55) + "…"
+              : entry.prompt
 
             return (
-              <li
-                key={entry.id}
-                className="flex items-center justify-between gap-3 px-6 py-3"
-              >
-                <div className="flex flex-col gap-1 min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="text-xs text-muted-foreground">
-                      {relativeTime(entry.timestamp)}
-                    </span>
-                    <Badge variant="outline" className="text-xs">
-                      {entry.institution}
-                    </Badge>
-                    <span className="text-xs text-muted-foreground">
-                      {entry.rowCount} rows
-                    </span>
-                  </div>
-                  <span
-                    className="text-sm truncate"
+              <li key={entry.id} className="px-4 py-3">
+                <button
+                  onClick={() => onRerun(entry)}
+                  className="w-full text-left group"
+                >
+                  <p
+                    className="text-xs font-medium text-foreground group-hover:text-primary transition-colors leading-snug"
                     title={entry.prompt}
                   >
                     {truncated}
-                  </span>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => onRerun(entry)}
-                  className="shrink-0"
-                >
-                  Re-run
-                </Button>
+                  </p>
+                  <div className="flex items-center gap-2 mt-1">
+                    <span className="text-[10px] text-muted-foreground">
+                      {relativeTime(entry.timestamp)}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground">·</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {entry.rowCount} rows
+                    </span>
+                  </div>
+                </button>
               </li>
             )
-          })}
-        </ul>
-      </CardContent>
-    </Card>
+          })
+        )}
+      </ul>
+
+      {/* Pinned footer */}
+      {entries.length > 0 && (
+        <div className="shrink-0 px-4 py-2 border-t">
+          <button
+            onClick={onClear}
+            className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+          >
+            Clear history
+          </button>
+        </div>
+      )}
+    </div>
   )
 }

--- a/codebenders-dashboard/components/query-history-panel.tsx
+++ b/codebenders-dashboard/components/query-history-panel.tsx
@@ -57,8 +57,8 @@ export function QueryHistoryPanel({ entries, onRerun, onClear }: QueryHistoryPan
           </li>
         ) : (
           entries.map((entry) => {
-            const truncated = entry.prompt.length > 55
-              ? entry.prompt.slice(0, 55) + "…"
+            const truncated = entry.prompt.length > 60
+              ? entry.prompt.slice(0, 60) + "…"
               : entry.prompt
 
             return (
@@ -74,12 +74,16 @@ export function QueryHistoryPanel({ entries, onRerun, onClear }: QueryHistoryPan
                     {truncated}
                   </p>
                   <div className="flex items-center gap-2 mt-1">
-                    <span className="text-[10px] text-muted-foreground">
+                    <span className="text-xs text-muted-foreground">
                       {relativeTime(entry.timestamp)}
                     </span>
-                    <span className="text-[10px] text-muted-foreground">·</span>
-                    <span className="text-[10px] text-muted-foreground">
+                    <span className="text-xs text-muted-foreground">·</span>
+                    <span className="text-xs text-muted-foreground">
                       {entry.rowCount} rows
+                    </span>
+                    <span className="text-xs text-muted-foreground">·</span>
+                    <span className="text-xs font-medium text-muted-foreground">
+                      {entry.institution}
                     </span>
                   </div>
                 </button>

--- a/codebenders-dashboard/lib/roles.ts
+++ b/codebenders-dashboard/lib/roles.ts
@@ -9,6 +9,7 @@ export const ROUTE_PERMISSIONS: Array<{ prefix: string; roles: Role[] }> = [
   { prefix: "/query",                    roles: ["admin", "advisor", "ir", "faculty"] },
   { prefix: "/api/students",             roles: ["admin", "advisor", "ir"] },
   { prefix: "/api/courses",             roles: ["admin", "advisor", "ir", "faculty"] },
+  { prefix: "/api/query-summary", roles: ["admin", "advisor", "ir", "faculty"] },
   { prefix: "/api/query-history/export", roles: ["admin", "ir"] },
 ]
 

--- a/docs/plans/2026-02-23-nql-redesign-design.md
+++ b/docs/plans/2026-02-23-nql-redesign-design.md
@@ -1,0 +1,114 @@
+# NQL Interface Redesign — Design Doc
+**Issue:** #88
+**Date:** 2026-02-23
+
+## Overview
+
+Three improvements to the Natural Query Language interface at `/query`:
+
+1. Add **Query** nav link to the global header
+2. Move query history into a **fixed left sidebar**
+3. Add an opt-in **Summarize** button that generates a plain-English LLM narrative of results
+
+---
+
+## Architecture
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `codebenders-dashboard/components/nav-header.tsx` | Add `{ href: "/query", label: "Query" }` to `NAV_LINKS` |
+| `codebenders-dashboard/app/query/page.tsx` | Redesign as sidebar + main two-column layout; add summarize state |
+| `codebenders-dashboard/components/query-history-panel.tsx` | Strip Card wrapper; adapt for sidebar use (full height, scrollable) |
+| `codebenders-dashboard/app/api/query-summary/route.ts` | New POST endpoint for LLM result summarization |
+
+---
+
+## Section 1: Nav link
+
+Add `{ href: "/query", label: "Query" }` to the `NAV_LINKS` array in `nav-header.tsx`.
+
+- Consistent with Dashboard / Courses / Students pattern
+- Middleware already guards `/query` for `admin, advisor, ir, faculty` roles
+- No role-filtering on the link itself (unauthorized users get redirected by middleware)
+
+---
+
+## Section 2: Sidebar layout
+
+**Desktop (≥ 768px):**
+```
+┌──────────┬──────────────────────────────────────┐
+│ History  │  Query Controls                      │
+│ sidebar  │  [Institution] [Prompt ▸▸▸] [Run]   │
+│ ~260px   │                                      │
+│ • q1     ├──────────────────────────────────────┤
+│ • q2     │  Analysis Results   [✦ Summarize]    │
+│ • q3     │  Chart / Table                       │
+│ …        │                                      │
+│          │  ── LLM summary paragraph ──         │
+│ [Export] │                                      │
+│ [Clear]  │  Query Plan (collapsible)            │
+└──────────┴──────────────────────────────────────┘
+```
+
+**Mobile (< 768px):** Sidebar hidden by default. A **History** toggle button in the page header opens it as an overlay drawer from the left.
+
+**QueryHistoryPanel changes:**
+- Remove `<Card>` wrapper — sidebar provides its own container
+- Make list `flex-1 overflow-y-auto` so it fills available height
+- Pin Export + Clear buttons to the bottom of the sidebar
+- Header ("Recent Queries") stays at the top
+
+**Page header:** Remove the "Back to Dashboard" `<Link>` — global nav covers navigation now. Keep the page title and description as a slim heading.
+
+---
+
+## Section 3: LLM result summary
+
+**UI:** After a successful query, a `Summarize` button (Sparkles icon, ghost variant) appears next to the "Analysis Results" heading. States:
+- Idle: `✦ Summarize`
+- Loading: `Generating…` (spinner)
+- Done: button hidden; summary paragraph renders below chart with a Sparkles icon prefix
+- Error: inline error message
+
+**Summary resets** when a new query is run.
+
+**API: `POST /api/query-summary`**
+
+Request body:
+```json
+{
+  "prompt": "retention by cohort for last two terms",
+  "data": [ ...up to 50 rows... ],
+  "rowCount": 12,
+  "vizType": "bar"
+}
+```
+
+Response:
+```json
+{ "summary": "The Fall 2022 cohort had the highest retention rate at 71%, ..." }
+```
+
+Implementation:
+- Uses `generateText` from `ai` SDK with `openai("gpt-4o-mini")`
+- Caps data rows at 50 before sending to LLM
+- `maxOutputTokens: 200` (2–3 sentences)
+- System prompt: advisor-friendly, data-driven, no speculation beyond the numbers
+- RBAC: `/api/query-summary` accessible to same roles as `/query`
+
+---
+
+## Frontend design
+
+The `frontend-design` skill must be invoked when implementing the query page layout and sidebar to ensure visual quality. The redesign should feel like a professional analytics workbench — not a generic form page.
+
+---
+
+## Out of scope
+
+- Streaming the summary (full text response is fine at 2–3 sentences)
+- Persisting summaries to localStorage or DB
+- Changing the SQL generation or execution logic

--- a/docs/plans/2026-02-23-nql-redesign.md
+++ b/docs/plans/2026-02-23-nql-redesign.md
@@ -1,0 +1,419 @@
+# NQL Interface Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a "Query" nav link, move query history into a fixed left sidebar, and add an opt-in LLM "Summarize" button that generates a plain-English narrative from query results.
+
+**Architecture:** Four file changes — nav link is a one-liner, the new `POST /api/query-summary` route reuses the existing `@ai-sdk/openai` + `generateText` pattern from other API routes, `QueryHistoryPanel` is stripped of its Card wrapper and made sidebar-native, and the query page is restructured as a two-column layout (260px sidebar + flex-1 main). Use the `frontend-design` skill for the page layout task.
+
+**Tech Stack:** Next.js 16 App Router, TypeScript, Tailwind CSS, shadcn/ui, `ai` v5 + `@ai-sdk/openai` v2, Lucide icons.
+
+**Design doc:** `docs/plans/2026-02-23-nql-redesign-design.md`
+
+---
+
+### Task 1: Add "Query" to global nav
+
+**Files:**
+- Modify: `codebenders-dashboard/components/nav-header.tsx`
+
+**Context:**
+`NAV_LINKS` is an array at the top of the file. The `/query` route is already RBAC-guarded in `lib/roles.ts` for `admin, advisor, ir, faculty`. The middleware injects `x-user-role` and redirects unauthorized users — no change to `roles.ts` needed for the nav link itself.
+
+**Step 1: Add the link**
+
+In `nav-header.tsx`, update `NAV_LINKS`:
+
+```ts
+const NAV_LINKS = [
+  { href: "/",        label: "Dashboard" },
+  { href: "/courses", label: "Courses"   },
+  { href: "/students", label: "Students" },
+  { href: "/query",   label: "Query"     },
+]
+```
+
+**Step 2: Verify type check passes**
+
+```bash
+cd codebenders-dashboard && npx tsc --noEmit
+```
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add codebenders-dashboard/components/nav-header.tsx
+git commit -m "feat: add Query link to global nav header (#88)"
+```
+
+---
+
+### Task 2: Create POST /api/query-summary route
+
+**Files:**
+- Create: `codebenders-dashboard/app/api/query-summary/route.ts`
+- Modify: `codebenders-dashboard/lib/roles.ts` (add RBAC entry)
+
+**Context:**
+Follow the exact pattern from `app/api/courses/explain-pairing/route.ts`:
+- Import `generateText` from `"ai"`, `createOpenAI` from `"@ai-sdk/openai"`
+- Instantiate `const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY || "" })`
+- Use `generateText({ model: openai("gpt-4o-mini"), prompt, maxOutputTokens: 200 })`
+- Return `NextResponse.json({ summary: result.text })`
+- Guard with `canAccess("/api/query-summary", role)`
+
+**Step 1: Add RBAC entry in `lib/roles.ts`**
+
+```ts
+{ prefix: "/api/query-summary", roles: ["admin", "advisor", "ir", "faculty"] },
+```
+
+Add it after the existing `/api/courses` entry.
+
+**Step 2: Create the route**
+
+```ts
+import { type NextRequest, NextResponse } from "next/server"
+import { canAccess, type Role } from "@/lib/roles"
+import { generateText } from "ai"
+import { createOpenAI } from "@ai-sdk/openai"
+
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY || "" })
+
+export async function POST(request: NextRequest) {
+  const role = request.headers.get("x-user-role") as Role | null
+  if (!role || !canAccess("/api/query-summary", role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return NextResponse.json({ error: "OpenAI API key not configured" }, { status: 500 })
+  }
+
+  const { prompt, data, rowCount, vizType } = await request.json()
+
+  if (!prompt || !Array.isArray(data)) {
+    return NextResponse.json({ error: "prompt and data are required" }, { status: 400 })
+  }
+
+  // Cap rows sent to LLM to avoid token overflow
+  const sampleRows = data.slice(0, 50)
+
+  const llmPrompt = `You are a student success analyst at a community college. An advisor ran the following query and got these results.
+
+QUERY: "${prompt}"
+RESULT: ${rowCount} rows, visualization type: ${vizType}
+DATA SAMPLE:
+${JSON.stringify(sampleRows, null, 2)}
+
+Write a 2-3 sentence plain-English summary of what these results show. Be specific about the numbers. Do not speculate beyond the data. Address the advisor directly.`
+
+  try {
+    const result = await generateText({
+      model: openai("gpt-4o-mini"),
+      prompt: llmPrompt,
+      maxOutputTokens: 200,
+    })
+    return NextResponse.json({ summary: result.text })
+  } catch (error) {
+    console.error("[query-summary] Error:", error)
+    return NextResponse.json(
+      { error: "Failed to generate summary", details: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    )
+  }
+}
+```
+
+**Step 3: Verify type check**
+
+```bash
+cd codebenders-dashboard && npx tsc --noEmit
+```
+Expected: no errors.
+
+**Step 4: Commit**
+
+```bash
+git add codebenders-dashboard/app/api/query-summary/route.ts \
+        codebenders-dashboard/lib/roles.ts
+git commit -m "feat: add POST /api/query-summary LLM result narration (#88)"
+```
+
+---
+
+### Task 3: Adapt QueryHistoryPanel for sidebar
+
+**Files:**
+- Modify: `codebenders-dashboard/components/query-history-panel.tsx`
+
+**Context:**
+Currently renders a `<Card>` with `<CardHeader>` and `<CardContent>`. In the sidebar it will be rendered inside an `<aside>` that provides the container. The component needs to fill the sidebar height (flex column, scrollable list, pinned footer).
+
+The props interface `{ entries, onRerun, onClear }` stays identical — only the markup changes.
+
+**Step 1: Rewrite the component markup**
+
+Replace the entire return value with:
+
+```tsx
+return (
+  <div className="flex flex-col h-full">
+    {/* Sidebar header */}
+    <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+      <span className="text-sm font-semibold">Recent Queries</span>
+      <a
+        href="/api/query-history/export"
+        download="query-audit-log.csv"
+        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        Export
+      </a>
+    </div>
+
+    {/* Scrollable list */}
+    <ul className="flex-1 overflow-y-auto divide-y divide-border">
+      {entries.length === 0 ? (
+        <li className="px-4 py-6 text-xs text-muted-foreground text-center">
+          No queries yet
+        </li>
+      ) : (
+        entries.map((entry) => {
+          const truncated = entry.prompt.length > 55
+            ? entry.prompt.slice(0, 55) + "…"
+            : entry.prompt
+
+          return (
+            <li key={entry.id} className="px-4 py-3">
+              <button
+                onClick={() => onRerun(entry)}
+                className="w-full text-left group"
+              >
+                <p
+                  className="text-xs font-medium text-foreground group-hover:text-primary transition-colors leading-snug"
+                  title={entry.prompt}
+                >
+                  {truncated}
+                </p>
+                <div className="flex items-center gap-2 mt-1">
+                  <span className="text-[10px] text-muted-foreground">
+                    {relativeTime(entry.timestamp)}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground">·</span>
+                  <span className="text-[10px] text-muted-foreground">
+                    {entry.rowCount} rows
+                  </span>
+                </div>
+              </button>
+            </li>
+          )
+        })
+      )}
+    </ul>
+
+    {/* Pinned footer */}
+    {entries.length > 0 && (
+      <div className="shrink-0 px-4 py-2 border-t">
+        <button
+          onClick={onClear}
+          className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+        >
+          Clear history
+        </button>
+      </div>
+    )}
+  </div>
+)
+```
+
+Also remove the now-unused imports: `Card`, `CardContent`, `CardHeader`, `CardTitle`, `Button`, `Download`, `Badge`.
+
+**Step 2: Verify type check and lint**
+
+```bash
+cd codebenders-dashboard && npx tsc --noEmit && npm run lint
+```
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add codebenders-dashboard/components/query-history-panel.tsx
+git commit -m "refactor: adapt QueryHistoryPanel for sidebar layout (#88)"
+```
+
+---
+
+### Task 4: Redesign query page with sidebar layout and Summarize button
+
+**Files:**
+- Modify: `codebenders-dashboard/app/query/page.tsx`
+
+**Context:**
+This is the most involved change. Use the **`frontend-design` skill** to implement the visual design — the page should feel like a professional analytics workbench, not a generic form. Read the design doc at `docs/plans/2026-02-23-nql-redesign-design.md` before starting.
+
+**Key structural changes:**
+- Outer container: `min-h-screen bg-background flex flex-col`
+- Slim page header bar: title + mobile sidebar toggle button
+- Body: `flex flex-1 overflow-hidden`
+  - `<aside>`: `hidden md:flex w-[260px] border-r flex-col shrink-0` — contains `<QueryHistoryPanel>`
+  - Mobile overlay: triggered by `sidebarOpen` state, shows sidebar as left drawer with backdrop
+  - `<main>`: `flex-1 overflow-auto p-6 space-y-6` — contains controls + results
+- Remove the "Back to Dashboard" `<Link>` (global nav covers navigation)
+
+**New state to add:**
+
+```ts
+const [sidebarOpen, setSidebarOpen] = useState(false)
+const [summary, setSummary] = useState<string | null>(null)
+const [summaryLoading, setSummaryLoading] = useState(false)
+const [summaryError, setSummaryError] = useState<string | null>(null)
+```
+
+**Reset summary when new query starts** — add these lines at the top of `handleAnalyze`:
+
+```ts
+setSummary(null)
+setSummaryError(null)
+```
+
+**Summarize handler:**
+
+```ts
+const handleSummarize = async () => {
+  if (!queryResult || !queryPlan) return
+  setSummaryLoading(true)
+  setSummaryError(null)
+  try {
+    const res = await fetch("/api/query-summary", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt,
+        data: queryResult.data,
+        rowCount: queryResult.rowCount,
+        vizType: queryPlan.vizType,
+      }),
+    })
+    const json = await res.json()
+    if (!res.ok) throw new Error(json.error || "Failed")
+    setSummary(json.summary)
+  } catch (e) {
+    setSummaryError(e instanceof Error ? e.message : String(e))
+  } finally {
+    setSummaryLoading(false)
+  }
+}
+```
+
+**Summarize button** — render inside or adjacent to the `<AnalysisResult>` card heading area. Pass `summary`, `summaryLoading`, `summaryError`, and `onSummarize` as props to a wrapper, OR render inline above/below `<AnalysisResult>`. Inline is simpler — wrap both in a section:
+
+```tsx
+{queryResult && queryPlan && (
+  <div className="space-y-3">
+    {/* Results header with Summarize button */}
+    <div className="flex items-center justify-between">
+      <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+        Results
+      </h2>
+      {!summary && (
+        <button
+          onClick={handleSummarize}
+          disabled={summaryLoading}
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 disabled:opacity-50 transition-colors"
+        >
+          {summaryLoading
+            ? <><Loader2 className="h-3 w-3 animate-spin" /> Generating…</>
+            : <><Sparkles className="h-3 w-3" /> Summarize</>}
+        </button>
+      )}
+    </div>
+
+    {/* LLM summary */}
+    {summary && (
+      <div className="flex gap-2 px-4 py-3 rounded-lg bg-muted/50 border">
+        <Sparkles className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+        <p className="text-sm text-foreground/90 leading-relaxed">{summary}</p>
+      </div>
+    )}
+    {summaryError && (
+      <p className="text-xs text-destructive">{summaryError}</p>
+    )}
+
+    {/* Existing results layout */}
+    <div className="grid gap-6 lg:grid-cols-[1fr_400px]">
+      <AnalysisResult result={queryResult} plan={queryPlan} />
+      <QueryPlanPanel plan={queryPlan} />
+    </div>
+  </div>
+)}
+```
+
+**New imports needed:** `Loader2`, `Sparkles`, `PanelLeft` (or `Menu`) from `lucide-react`.
+
+**Mobile sidebar overlay:**
+
+```tsx
+{/* Mobile sidebar overlay */}
+{sidebarOpen && (
+  <div className="fixed inset-0 z-50 md:hidden">
+    <div
+      className="absolute inset-0 bg-background/80 backdrop-blur-sm"
+      onClick={() => setSidebarOpen(false)}
+    />
+    <aside className="absolute left-0 top-0 bottom-0 w-[260px] bg-background border-r flex flex-col">
+      <QueryHistoryPanel entries={history} onRerun={handleRerun} onClear={handleClear} />
+    </aside>
+  </div>
+)}
+```
+
+**Mobile toggle button** in the slim page header:
+
+```tsx
+<button
+  onClick={() => setSidebarOpen(true)}
+  className="md:hidden p-1 rounded text-muted-foreground hover:text-foreground"
+>
+  <PanelLeft className="h-4 w-4" />
+</button>
+```
+
+**Step 1: Invoke the `frontend-design` skill**
+
+Before writing code, invoke `frontend-design` skill with this brief:
+
+> "Redesign the `/query` page as an analytics workbench with a fixed 260px left sidebar for query history and a main content area on the right. The page has a slim header bar (title + mobile toggle), sidebar (history list, scrollable, pinned footer), and main (query controls card, results section with Summarize button, chart/table). Match the existing shadcn/ui dashboard aesthetic. Avoid generic AI design — go for a refined, focused analytics tool feel."
+
+Use the generated design guidance for color, spacing, and typography decisions while implementing the structural changes above.
+
+**Step 2: Implement the page**
+
+Apply all structural changes documented above. Keep all existing logic (`handleAnalyze`, `handleRerun`, `handleClear`) unchanged.
+
+**Step 3: Verify type check, lint, and build**
+
+```bash
+cd codebenders-dashboard && npx tsc --noEmit && npm run lint && npm run build
+```
+Expected: no errors or type failures.
+
+**Step 4: Commit**
+
+```bash
+git add codebenders-dashboard/app/query/page.tsx
+git commit -m "feat: sidebar layout + LLM Summarize button on query page (#88)"
+```
+
+---
+
+## Final verification
+
+After all tasks:
+
+```bash
+cd codebenders-dashboard && npx tsc --noEmit && npm run lint && npm run build
+```
+
+All three must pass before creating the PR.


### PR DESCRIPTION
## Summary

- Add **Query** to the global nav header so advisors can reach the query interface from any page
- Redesign the `/query` page as a two-column analytics workbench: fixed 260px left sidebar for scrollable query history (with Export + Clear actions) and a mobile overlay drawer triggered by a header toggle
- Add opt-in **Summarize** button next to query results that calls a new `POST /api/query-summary` endpoint, generating a 2–3 sentence plain-English narrative from the result data via `gpt-4o-mini`

## Changes

| File | Change |
|------|--------|
| `components/nav-header.tsx` | Added `{ href: "/query", label: "Query" }` to `NAV_LINKS` |
| `app/api/query-summary/route.ts` | New POST endpoint — RBAC-guarded, caps data at 50 rows, `maxOutputTokens: 200` |
| `lib/roles.ts` | Added RBAC entry for `/api/query-summary` (admin, advisor, ir, faculty) |
| `components/query-history-panel.tsx` | Stripped Card wrapper; sidebar-native flex layout with pinned header/footer |
| `app/query/page.tsx` | Two-column layout, mobile drawer, Summarize button + summary card, summary resets on new query |

## Test Plan

- [ ] `Query` link appears in global nav and navigates to `/query`
- [ ] Unauthorized roles (e.g. `leadership`) are redirected by middleware, not by nav filtering
- [ ] On desktop (≥ 768px): query history sidebar is visible on the left, scrollable
- [ ] On mobile (< 768px): sidebar is hidden; tap the toggle opens the history drawer with backdrop; tapping backdrop closes it
- [ ] Run a query → Summarize button appears; click it → spinner → summary paragraph renders below results; button hides
- [ ] Run a second query → summary clears before new results load
- [ ] Export link downloads `query-audit-log.csv`; Clear removes all history entries
- [ ] `POST /api/query-summary` returns 403 for unauthenticated requests and 400 for missing `prompt`/`data`
- [ ] TypeScript: `npx tsc --noEmit` exits 0
- [ ] Lint: `npm run lint` exits 0 errors (5 pre-existing warnings)

Closes #88