### PR TITLE
feat: AASCU intermediary discovery report — gap analysis + dashboard pages

### DIFF
--- a/codebenders-dashboard/app/discovery/aascu/full/page.module.css
+++ b/codebenders-dashboard/app/discovery/aascu/full/page.module.css
@@ -1,0 +1,600 @@
+.doc {
+  --paper: #f5efe4;
+  --paper-deep: #ece3d2;
+  --ink: #1a1714;
+  --ink-soft: #3b342c;
+  --muted: #857a68;
+  --rule: #d6cbb5;
+  --accent: #b8531a;
+  --accent-deep: #8a3d12;
+  --done: #4f6539;
+  --partial: #a87f1f;
+  --gap: #8b2f2a;
+  --p0: #8b2f2a;
+  --p1: #a87f1f;
+  --p2: #5d6b76;
+
+  background-color: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-plex-sans), ui-sans-serif, system-ui, sans-serif;
+  font-weight: 400;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  min-height: calc(100vh - 48px);
+
+  background-image:
+    radial-gradient(circle at 20% 10%, rgba(184, 83, 26, 0.04), transparent 40%),
+    radial-gradient(circle at 80% 80%, rgba(26, 23, 20, 0.05), transparent 50%),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='140' height='140'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.10 0 0 0 0 0.09 0 0 0 0 0.08 0 0 0 0 0.04 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  background-attachment: fixed;
+}
+
+.inner {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 64px 56px 120px;
+}
+
+.mast {
+  border-top: 2px solid var(--ink);
+  border-bottom: 1px solid var(--ink);
+  padding: 18px 0 22px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  gap: 24px;
+  animation: fadeUp 0.8s ease-out both;
+}
+
+.lockup {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.lockup b { color: var(--accent); font-weight: 500; }
+
+.mastMeta {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  text-align: right;
+  line-height: 1.7;
+}
+
+.hero {
+  padding: 80px 0 64px;
+  border-bottom: 1px solid var(--rule);
+  position: relative;
+}
+
+.eyebrow {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 28px;
+  animation: fadeUp 0.9s 0.1s ease-out both;
+}
+
+.h1 {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 144, "SOFT" 30;
+  font-weight: 340;
+  font-size: clamp(48px, 7.2vw, 108px);
+  line-height: 0.94;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+  margin-bottom: 32px;
+  animation: fadeUp 1s 0.15s ease-out both;
+}
+.h1 em {
+  font-style: italic;
+  font-weight: 300;
+  color: var(--accent);
+  font-variation-settings: "opsz" 144, "SOFT" 80;
+}
+
+.lede {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 36;
+  font-weight: 330;
+  font-size: clamp(20px, 1.7vw, 24px);
+  line-height: 1.45;
+  color: var(--ink-soft);
+  max-width: 780px;
+  animation: fadeUp 1s 0.25s ease-out both;
+}
+
+.strip {
+  margin-top: 56px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--rule);
+  animation: fadeUp 1s 0.35s ease-out both;
+}
+.strip > div {
+  padding: 18px 20px 4px 0;
+  border-right: 1px solid var(--rule);
+}
+.strip > div:last-child { border-right: none; padding-right: 0; }
+.strip dt {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.strip dd {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 60;
+  font-weight: 340;
+  font-size: 34px;
+  line-height: 1;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+.strip dd small {
+  display: block;
+  font-family: var(--font-plex-sans);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-top: 8px;
+  font-weight: 400;
+}
+
+.chapter {
+  padding: 88px 0 24px;
+  border-bottom: 1px solid var(--rule);
+}
+.chapter:last-of-type { border-bottom: none; }
+
+.chapHead {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 48px;
+  margin-bottom: 56px;
+  align-items: start;
+}
+.chapNum {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 144, "SOFT" 0;
+  font-weight: 300;
+  font-size: 96px;
+  line-height: 0.85;
+  color: var(--accent);
+  letter-spacing: -0.04em;
+}
+.chapNum span {
+  display: block;
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-top: 14px;
+}
+.chapTitle {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 60;
+  font-weight: 360;
+  font-size: clamp(32px, 3.6vw, 52px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  max-width: 780px;
+}
+.chapTitle em {
+  font-style: italic;
+  font-weight: 300;
+  color: var(--accent);
+  font-variation-settings: "opsz" 60, "SOFT" 80;
+}
+.chapKicker {
+  font-family: var(--font-plex-sans);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink-soft);
+  margin-top: 18px;
+  max-width: 680px;
+}
+
+.pains {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+}
+.pain {
+  background: var(--paper);
+  padding: 32px 30px 36px;
+  position: relative;
+}
+.painTag {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 14px;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+.painTag::before {
+  content: "";
+  width: 14px;
+  height: 1px;
+  background: var(--accent);
+}
+.painH {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 36;
+  font-weight: 380;
+  font-size: 23px;
+  line-height: 1.2;
+  color: var(--ink);
+  margin-bottom: 16px;
+  letter-spacing: -0.01em;
+}
+.painList { list-style: none; padding: 0; margin: 0; }
+.painList li {
+  position: relative;
+  padding-left: 18px;
+  margin-bottom: 10px;
+  font-size: 14.5px;
+  line-height: 1.55;
+  color: var(--ink-soft);
+}
+.painList li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.65em;
+  width: 6px;
+  height: 1px;
+  background: var(--ink-soft);
+}
+.painList li strong { color: var(--ink); font-weight: 500; }
+
+.pq {
+  margin: 64px auto;
+  max-width: 880px;
+  padding: 0 24px;
+  text-align: center;
+}
+.pq blockquote {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+  font-style: italic;
+  font-weight: 320;
+  font-size: clamp(26px, 3vw, 40px);
+  line-height: 1.25;
+  color: var(--ink);
+  letter-spacing: -0.015em;
+}
+.pq blockquote::before {
+  content: "\201C";
+  display: block;
+  font-size: 96px;
+  line-height: 0.5;
+  color: var(--accent);
+  margin-bottom: 8px;
+  opacity: 0.7;
+}
+.pq cite {
+  display: block;
+  margin-top: 24px;
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-style: normal;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 140px 1.2fr 1.4fr 0.7fr;
+  gap: 32px;
+  padding: 22px 0;
+  border-bottom: 1px solid var(--rule);
+  align-items: start;
+}
+.row:first-child { border-top: 1px solid var(--ink); }
+.rowHead {
+  padding: 14px 0;
+  border-bottom: 1px solid var(--ink);
+}
+.rowHead > div {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.pp {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.name {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 24;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.3;
+  color: var(--ink);
+  letter-spacing: -0.005em;
+}
+.ev {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--ink-soft);
+}
+.ev code {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 12px;
+  background: var(--paper-deep);
+  padding: 1px 6px;
+  border-radius: 2px;
+  color: var(--ink);
+}
+
+.stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+.stat::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.statDone { color: var(--done); }
+.statDone::before { background: var(--done); }
+.statPartial { color: var(--partial); }
+.statPartial::before { background: var(--partial); }
+
+.tier { margin-bottom: 56px; }
+.tierHead {
+  display: flex;
+  align-items: baseline;
+  gap: 24px;
+  margin-bottom: 28px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--ink);
+}
+.tierPill {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  padding: 6px 14px;
+  border-radius: 2px;
+  color: var(--paper);
+}
+.pill0 { background: var(--p0); }
+.pill1 { background: var(--p1); }
+.pill2 { background: var(--p2); }
+.tierH {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 36;
+  font-weight: 370;
+  font-size: 24px;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+.tierH em { font-style: italic; color: var(--muted); font-weight: 330; }
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+}
+.cardsTwo { grid-template-columns: repeat(2, 1fr); }
+
+.card {
+  background: var(--paper);
+  padding: 28px 26px 32px;
+  display: flex;
+  flex-direction: column;
+  transition: background 0.25s ease, transform 0.25s ease;
+  text-decoration: none;
+  color: inherit;
+}
+.card:hover { background: var(--paper-deep); transform: translateY(-2px); }
+
+.cardNum {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-bottom: 14px;
+  display: flex;
+  justify-content: space-between;
+}
+.cardNum b { color: var(--ink); font-weight: 500; letter-spacing: 0.1em; }
+.cardH {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 30;
+  font-weight: 400;
+  font-size: 21px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  margin-bottom: 14px;
+}
+.cardTag {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 10px;
+}
+.cardP {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--ink-soft);
+  margin-bottom: auto;
+}
+.cardLink {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px dotted var(--rule);
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.cardLink::after { content: " →"; }
+
+.summary {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 64px;
+  align-items: start;
+}
+.summary aside {
+  border-top: 2px solid var(--ink);
+  padding-top: 18px;
+}
+.summary aside h5 {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 18px;
+  font-weight: 500;
+}
+.summary aside ul { list-style: none; padding: 0; }
+.summary aside li {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 24;
+  font-size: 18px;
+  line-height: 1.35;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--rule);
+  color: var(--ink);
+}
+.summary aside li::before {
+  content: attr(data-n);
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  margin-right: 14px;
+  vertical-align: 2px;
+}
+.summary .body p {
+  font-family: var(--font-fraunces), ui-serif, Georgia, serif;
+  font-variation-settings: "opsz" 24;
+  font-weight: 340;
+  font-size: 21px;
+  line-height: 1.55;
+  color: var(--ink);
+  margin-bottom: 18px;
+  letter-spacing: -0.005em;
+}
+.summary .body p strong { color: var(--accent); font-weight: 450; }
+.summary .body p em { font-style: italic; color: var(--ink-soft); }
+
+.scope {
+  margin-top: 48px;
+  padding: 32px 0 0;
+  border-top: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 48px;
+}
+.scope h6 {
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 500;
+}
+.scope ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+.scope li {
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  padding-left: 14px;
+  position: relative;
+}
+.scope li::before {
+  content: "\00d7";
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--gap);
+  font-weight: 500;
+}
+
+.colophon {
+  margin-top: 96px;
+  padding-top: 24px;
+  border-top: 2px solid var(--ink);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  font-family: var(--font-jb-mono), ui-monospace, monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.colophon b { color: var(--ink); font-weight: 500; }
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 920px) {
+  .inner { padding: 32px 22px 80px; }
+  .h1 { font-size: 54px; }
+  .strip { grid-template-columns: repeat(2, 1fr); }
+  .strip > div { padding: 18px 16px 4px 0; }
+  .strip > div:nth-child(2n) { border-right: none; }
+  .strip > div:nth-child(-n+2) { border-bottom: 1px solid var(--rule); }
+  .chapHead { grid-template-columns: 1fr; gap: 20px; }
+  .chapNum { font-size: 64px; }
+  .pains { grid-template-columns: 1fr; }
+  .row { grid-template-columns: 1fr; gap: 8px; padding: 18px 0; }
+  .summary { grid-template-columns: 1fr; gap: 36px; }
+  .cards, .cardsTwo { grid-template-columns: 1fr; }
+  .scope { grid-template-columns: 1fr; gap: 18px; }
+  .scope ul { grid-template-columns: 1fr; }
+}

--- a/codebenders-dashboard/app/discovery/aascu/full/page.tsx
+++ b/codebenders-dashboard/app/discovery/aascu/full/page.tsx
@@ -1,0 +1,332 @@
+import type { Metadata } from "next"
+import { Fraunces, IBM_Plex_Sans, JetBrains_Mono } from "next/font/google"
+import styles from "./page.module.css"
+
+const fraunces = Fraunces({
+  variable: "--font-fraunces",
+  subsets: ["latin"],
+  axes: ["opsz", "SOFT"],
+})
+
+const plexSans = IBM_Plex_Sans({
+  variable: "--font-plex-sans",
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600"],
+  style: ["normal", "italic"],
+})
+
+const jbMono = JetBrains_Mono({
+  variable: "--font-jb-mono",
+  subsets: ["latin"],
+  weight: ["400", "500"],
+})
+
+export const metadata: Metadata = {
+  title: "AASCU Intermediary Discovery — Gap Analysis",
+  description: "Editorial report on the AASCU intermediary discovery session: pain points, what the tool already addresses, and gaps filed as issues.",
+}
+
+const ISSUE_BASE = "https://github.com/devcolor/codebenders-datathon/issues"
+
+const PAINS = [
+  {
+    tag: "A · Data accuracy & trust",
+    h: "Numbers that don’t add up",
+    items: [
+      <>Incorrect cohort sizes; campuses missing from dashboard dropdowns.</>,
+      <>Dashboard <strong>pulls from the wrong dataset</strong> intermittently.</>,
+      <>Submission-time processing corrupts otherwise-clean institutional data.</>,
+      <>No cross-source verification — intermediaries and institutions take each other&rsquo;s word.</>,
+    ],
+  },
+  {
+    tag: "B · Definitions & terminology",
+    h: "The glossary that isn’t there",
+    items: [
+      <>“Completion at 3/4/5 years” and retention metrics undefined in-context.</>,
+      <>Definitions live in <strong>external documentation</strong>, not the dashboard.</>,
+      <>Terms diverge from IPEDS and state-compliance vocabulary IR staff already use.</>,
+    ],
+  },
+  {
+    tag: "C · Visualization & export",
+    h: "Charts you can’t show your boss",
+    items: [
+      <>Wrong chart types — line graph for independent cohorts where bar is correct.</>,
+      <>Charts <strong>not presentation-ready</strong>; IR staff rebuild in Excel by hand.</>,
+      <>No data download from dashboard. Analysis-ready file is a <strong>$20K paywall</strong>.</>,
+    ],
+  },
+  {
+    tag: "D · AI & governance",
+    h: "FERPA is the floor, not the ceiling",
+    items: [
+      <>“Weaponizing data” risk to under-resourced campuses via context-free AI inference.</>,
+      <>Sensitive populations — immigrant, undocumented, public-aid — need explicit care.</>,
+      <>Demand for full <strong>data lineage</strong>, model transparency, storage disclosure.</>,
+    ],
+  },
+  {
+    tag: "E · Institutional process",
+    h: "One person knows; one person retires",
+    items: [
+      <>Submission knowledge silos with one IR staffer per institution.</>,
+      <>Each campus has wildly different submission rituals — some delist + re-upload everything every cycle.</>,
+      <>“Best edit resolution” loses to <strong>people-and-process bottlenecks</strong>.</>,
+    ],
+  },
+  {
+    tag: "F · Datathon coordination",
+    h: "Group by goal, not just SIS",
+    items: [
+      <>AASCU has SIS-by-institution list — can rank by commonality or by need.</>,
+      <>Last datathon: wildly different institutional incomes ate most of the day.</>,
+      <>Recommend grouping by <strong>shared SIS + shared goal</strong> (e.g., advising).</>,
+    ],
+  },
+]
+
+const COVERAGE: Array<{
+  pp: string
+  name: string
+  ev: React.ReactNode
+  status: "done" | "partial"
+  statusLabel: string
+}> = [
+  { pp: "C · Export", name: "CSV export wired into dashboard", ev: <><code>components/export-button.tsx</code> · issue #15</>, status: "done", statusLabel: "Done" },
+  { pp: "C · Visualization", name: "Recharts components, types chosen per metric", ev: <><code>retention-risk-chart.tsx</code>, <code>risk-alert-chart.tsx</code>, <code>readiness-assessment-chart.tsx</code></>, status: "done", statusLabel: "Done" },
+  { pp: "B · Definitions", name: "Tooltip primitive exists; no centralized glossary yet", ev: <><code>components/info-popover.tsx</code></>, status: "partial", statusLabel: "Partial" },
+  { pp: "D · Methodology", name: "How predictions are made — surfaced in-app", ev: <><code>app/methodology/</code> route</>, status: "done", statusLabel: "Done" },
+  { pp: "D · FERPA", name: "RBAC, audit log, FERPA-compliant identity resolution", ev: <>Issues #67, #75, #77, #78 (closed)</>, status: "done", statusLabel: "Done" },
+  { pp: "D · Automation", name: "Self-service upload (PDP, AR, student, course)", ev: <>Issue #86 (closed) · <code>components/upload/</code></>, status: "done", statusLabel: "Done" },
+  { pp: "D · Explainability", name: "SHAP narrator — fine-tuning epic in progress", ev: <>Issues #97 — #103 · branch <code>fine-tuning/97-shap-narrator-task-type</code></>, status: "partial", statusLabel: "In flight" },
+  { pp: "A · Validation", name: "Upload exists; human-readable validation report missing", ev: <>Addressed by new issue #110</>, status: "partial", statusLabel: "Partial" },
+  { pp: "C · Filtering", name: "By cohort, term, demographic, credential type", ev: <>Issues #66, #81 (closed)</>, status: "done", statusLabel: "Done" },
+  { pp: "C · Query", name: "Natural-language query against the data", ev: <><code>lib/prompt-analyzer.ts</code> · issues #17, #61, #88, #90</>, status: "done", statusLabel: "Done" },
+  { pp: "E · Knowledge", name: "Self-service upload reduces single-person dependency", ev: <>In-app submission runbook missing — addressed by #111</>, status: "partial", statusLabel: "Partial" },
+]
+
+const TIERS: Array<{
+  pri: "p0" | "p1" | "p2"
+  pillLabel: string
+  h: React.ReactNode
+  twoCol?: boolean
+  cards: Array<{ num: number; tag: string; title: string; body: React.ReactNode }>
+}> = [
+  {
+    pri: "p0",
+    pillLabel: "P0 · Differentiators",
+    h: <>Match the loudest complaints. <em>Datathon-eligible.</em></>,
+    cards: [
+      { num: 105, tag: "Pain B · Definitions", title: "Metric definitions glossary with IPEDS & state-compliance cross-walks", body: <>Every KPI surfaces a tooltip with PDP, IPEDS, and state-compliance equivalents. Centralized <code>/glossary</code> page indexed by metric. Markdown source-of-truth, versioned with the code.</> },
+      { num: 106, tag: "Pain C · Export", title: "Presentation-ready chart export (PNG / PDF)", body: <>Every chart exports as a polished image with title, definition, source, and date stamp baked in. Eliminates the manual Excel-rebuild workflow IR staff perform daily.</> },
+      { num: 107, tag: "Pain A + D · Lineage", title: "Data lineage view — “where did this number come from”", body: <>Click any number → see source rows, upload event, transformations, and timestamps. The single highest-leverage gap from the session: directly answers trust + governance + differentiation in one feature.</> },
+    ],
+  },
+  {
+    pri: "p1",
+    pillLabel: "P1 · Governance hardening",
+    h: <>Table-stakes for institutional adoption.</>,
+    cards: [
+      { num: 108, tag: "Pain D · Transparency", title: "AI Transparency Page", body: <>Per-model disclosure: features used, training data source, homegrown vs. third-party, where data flows when invoked, retention policy. Reviewable independently by institutional IT &amp; legal.</> },
+      { num: 109, tag: "Pain D · Sensitive populations", title: "Sensitive-population safeguards", body: <>Per-institution feature-exclusion lists. Context warnings on small sub-populations. Audit log entries for any query touching flagged groups. Demoable, not just claimed.</> },
+      { num: 110, tag: "Pain A + E · Validation", title: "Upload validation report — diff vs. last upload", body: <>Row-level errors, field coercions, dedup decisions, anomaly flags (&ldquo;3 campuses dropped from this upload&rdquo;). Readable by non-technical IR staff. Survives the &ldquo;person retires&rdquo; scenario.</> },
+    ],
+  },
+  {
+    pri: "p2",
+    pillLabel: "P2 · Process & institutional fit",
+    h: <>Lower urgency, higher institutional gratitude.</>,
+    twoCol: true,
+    cards: [
+      { num: 111, tag: "Pain E · Process", title: "Submission runbook generator", body: <>Tool records the upload steps + field mappings that worked, then generates a printable runbook so a successor can replicate without tribal knowledge. Replayable on new files.</> },
+      { num: 112, tag: "Pain F · Datathon coordination", title: "Institution-grouping helper — shared SIS + shared goal", body: <>Operational artifact, not a user feature: cross-reference AASCU&rsquo;s SIS list with stated institutional goals; output a candidate cohort matrix for the fall datathon.</> },
+    ],
+  },
+]
+
+const pillClass = (pri: "p0" | "p1" | "p2") =>
+  pri === "p0" ? styles.pill0 : pri === "p1" ? styles.pill1 : styles.pill2
+
+const statClass = (s: "done" | "partial") =>
+  s === "done" ? styles.statDone : styles.statPartial
+
+export default function AASCUFullPage() {
+  return (
+    <div className={`${fraunces.variable} ${plexSans.variable} ${jbMono.variable} ${styles.doc}`}>
+      <div className={styles.inner}>
+
+        <header className={styles.mast}>
+          <div className={styles.lockup}>
+            Codebenders Datathon · <b>Discovery Report №&nbsp;01</b> · Bishop&nbsp;State&nbsp;CC
+          </div>
+          <div className={styles.mastMeta}>
+            Filed&nbsp;2026·04·29<br />
+            Source: 21-min&nbsp;recording + notes<br />
+            Status: Stakeholder review
+          </div>
+        </header>
+
+        <section className={styles.hero}>
+          <div className={styles.eyebrow}>AASCU Intermediary Discovery — Gap Analysis</div>
+          <h1 className={styles.h1}>The data they have <em>isn&rsquo;t</em> the data they trust.</h1>
+          <p className={styles.lede}>
+            Two AASCU intermediaries described, in their own words, why the Postsecondary Data Partnership dashboard fails the institutions they support — and where a tool built around <em>provable</em>, <em>presentable</em>, <em>governed</em> outputs would land.
+          </p>
+          <dl className={styles.strip}>
+            <div><dt>Recording</dt><dd>20:58<small>minutes of testimony</small></dd></div>
+            <div><dt>Voices</dt><dd>2<small>intermediaries · IR + data&#8209;eng</small></dd></div>
+            <div><dt>Pain themes</dt><dd>6<small>mapped across stack</small></dd></div>
+            <div><dt>Issues filed</dt><dd>8<small>#105 — #112</small></dd></div>
+          </dl>
+        </section>
+
+        <section className={styles.chapter}>
+          <div className={styles.chapHead}>
+            <div className={styles.chapNum}>01<span>Executive summary</span></div>
+            <div>
+              <h2 className={styles.chapTitle}>A tool worth adopting is one that <em>institutions can defend</em> — to legal, to leadership, to themselves.</h2>
+              <p className={styles.chapKicker}>The intermediaries don&rsquo;t need another dashboard. They need outputs they can present upward, prove the provenance of, and govern responsibly when sensitive student populations are involved.</p>
+            </div>
+          </div>
+          <div className={styles.summary}>
+            <aside>
+              <h5>Three layers of pain</h5>
+              <ul>
+                <li data-n="01">PDP dashboard quality</li>
+                <li data-n="02">AI &amp; data governance</li>
+                <li data-n="03">Institutional process</li>
+              </ul>
+            </aside>
+            <div className="body">
+              <p>Two AASCU intermediaries described pain in three layers: <strong>PDP dashboard quality</strong> — inaccurate cohort numbers, buried definitions, wrong chart types, no data export — forcing IR staff into manual Excel rebuilds; <strong>AI/governance requirements</strong> — FERPA-plus expectations including data lineage, transparency, and explicit safeguards for sensitive student populations; and <strong>institutional process gaps</strong> — submission knowledge that lives with one person and varies wildly across campuses.</p>
+              <p>Our tool already addresses a meaningful share of layer one — CSV export, sane chart types, NLQ, methodology page — and is in-flight on layer two via the SHAP-narrator work. The biggest unaddressed gaps are <em>a definitions glossary with IPEDS / state-compliance cross-walks, presentation-ready chart export, a data-lineage view that proves where each number came from, and AI transparency + sensitive-population safeguards as a precondition for institutional adoption.</em></p>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.chapter}>
+          <div className={styles.chapHead}>
+            <div className={styles.chapNum}>02<span>What we heard</span></div>
+            <div>
+              <h2 className={styles.chapTitle}>Six themes — <em>raised independently</em> by both intermediaries.</h2>
+              <p className={styles.chapKicker}>Andres (IR-focused) and Dr. Prateek (data-engineering-focused) emphasized different layers, but converged on a common diagnosis: institutions can&rsquo;t trust, can&rsquo;t present, and can&rsquo;t govern what PDP gives them today.</p>
+            </div>
+          </div>
+
+          <div className={styles.pains}>
+            {PAINS.map((p) => (
+              <div key={p.tag} className={styles.pain}>
+                <div className={styles.painTag}>{p.tag}</div>
+                <h3 className={styles.painH}>{p.h}</h3>
+                <ul className={styles.painList}>
+                  {p.items.map((it, i) => <li key={i}>{it}</li>)}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className={styles.pq}>
+          <blockquote>Why on earth would they invest any time in learning this new tool?</blockquote>
+          <cite>— Intermediary, on PDP&rsquo;s compounding friction · 21-min recording, 03:42</cite>
+        </div>
+
+        <section className={styles.chapter}>
+          <div className={styles.chapHead}>
+            <div className={styles.chapNum}>03<span>What the tool already does</span></div>
+            <div>
+              <h2 className={styles.chapTitle}>A meaningful share of the pain is <em>already addressed</em> in <code>codebenders-dashboard</code>.</h2>
+              <p className={styles.chapKicker}>Mapping each pain point to the closed PRs and shipped components. Status reflects the state of the codebase as of this report.</p>
+            </div>
+          </div>
+
+          <div>
+            <div className={`${styles.row} ${styles.rowHead}`}>
+              <div>Pain point</div>
+              <div>Capability</div>
+              <div>Evidence</div>
+              <div>Status</div>
+            </div>
+            {COVERAGE.map((row, i) => (
+              <div key={i} className={styles.row}>
+                <div className={styles.pp}>{row.pp}</div>
+                <div className={styles.name}>{row.name}</div>
+                <div className={styles.ev}>{row.ev}</div>
+                <div>
+                  <span className={`${styles.stat} ${statClass(row.status)}`}>
+                    {row.statusLabel}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className={styles.pq}>
+          <blockquote>I just went by each data point and copied that number into the Excel spreadsheet.</blockquote>
+          <cite>— Dr. Prateek, on rebuilding PDP outputs by hand · 04:58</cite>
+        </div>
+
+        <section className={styles.chapter}>
+          <div className={styles.chapHead}>
+            <div className={styles.chapNum}>04<span>Gaps — issues filed</span></div>
+            <div>
+              <h2 className={styles.chapTitle}>Eight issues, three priority tiers, one through-line: <em>provable, presentable, governed</em>.</h2>
+              <p className={styles.chapKicker}>Each issue links back to a specific quote or recurring complaint from the discovery session. Out-of-scope items are listed at the end and intentionally not filed.</p>
+            </div>
+          </div>
+
+          {TIERS.map((tier) => (
+            <div key={tier.pri} className={styles.tier}>
+              <div className={styles.tierHead}>
+                <span className={`${styles.tierPill} ${pillClass(tier.pri)}`}>{tier.pillLabel}</span>
+                <h3 className={styles.tierH}>{tier.h}</h3>
+              </div>
+              <div className={`${styles.cards} ${tier.twoCol ? styles.cardsTwo : ""}`}>
+                {tier.cards.map((c) => (
+                  <a
+                    key={c.num}
+                    className={styles.card}
+                    href={`${ISSUE_BASE}/${c.num}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <div className={styles.cardNum}>
+                      <span>Issue</span>
+                      <b>#{c.num}</b>
+                    </div>
+                    <div className={styles.cardTag}>{c.tag}</div>
+                    <h4 className={styles.cardH}>{c.title}</h4>
+                    <p className={styles.cardP}>{c.body}</p>
+                    <div className={styles.cardLink}>Open issue</div>
+                  </a>
+                ))}
+              </div>
+            </div>
+          ))}
+
+          <div className={styles.scope}>
+            <h6>Intentionally<br />out of scope</h6>
+            <ul>
+              <li>PDP-side cohort accuracy and dropdown completeness — that&rsquo;s PDP&rsquo;s bug to fix; we shouldn&rsquo;t build around it.</li>
+              <li>The $20K analysis-ready file paywall — pricing decision by PDP; not addressable here.</li>
+              <li>Vendor over-promising on &ldquo;full automation&rdquo; — competitive-positioning concern, not a feature.</li>
+            </ul>
+          </div>
+        </section>
+
+        <footer className={styles.colophon}>
+          <div>
+            <b>AASCU Intermediary Discovery</b> · Gap Analysis<br />
+            Set in Fraunces &amp; IBM Plex Sans · Filed 2026·04·29
+          </div>
+          <div>
+            Codebenders&nbsp;Datathon · <b>Bishop&nbsp;State&nbsp;CC</b>
+          </div>
+        </footer>
+
+      </div>
+    </div>
+  )
+}

--- a/codebenders-dashboard/app/discovery/aascu/page.module.css
+++ b/codebenders-dashboard/app/discovery/aascu/page.module.css
@@ -1,0 +1,250 @@
+.doc {
+  --bg: #fafaf7;
+  --ink: #15181a;
+  --soft: #4a4f53;
+  --muted: #7d8489;
+  --rule: #e3e1da;
+  --accent: #0f5c4d;
+  --accent-soft: #e8efe9;
+  --done: #0f5c4d;
+  --partial: #9a6d12;
+  --gap: #8b3a3a;
+
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-plex-sans), ui-sans-serif, system-ui, sans-serif;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  min-height: calc(100vh - 48px);
+}
+
+.inner {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 56px 32px 96px;
+}
+
+.header {
+  padding-bottom: 32px;
+  border-bottom: 1px solid var(--ink);
+  margin-bottom: 48px;
+}
+
+.kicker {
+  font-family: var(--font-plex-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 18px;
+}
+
+.h1 {
+  font-family: var(--font-newsreader), ui-serif, Georgia, serif;
+  font-weight: 400;
+  font-size: 42px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin-bottom: 14px;
+}
+
+.lede {
+  font-family: var(--font-newsreader), ui-serif, Georgia, serif;
+  font-weight: 400;
+  font-size: 19px;
+  line-height: 1.5;
+  color: var(--soft);
+  max-width: 620px;
+}
+
+.meta {
+  margin-top: 24px;
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  font-family: var(--font-plex-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.meta b { color: var(--ink); font-weight: 500; }
+
+.section { margin-bottom: 56px; }
+
+.h2 {
+  font-family: var(--font-plex-mono), ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 24px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--rule);
+  font-weight: 500;
+}
+
+.tldr {
+  background: var(--accent-soft);
+  border-left: 3px solid var(--accent);
+  padding: 24px 28px;
+  border-radius: 2px;
+}
+
+.tldr p {
+  font-family: var(--font-newsreader), ui-serif, Georgia, serif;
+  font-size: 18px;
+  line-height: 1.55;
+  color: var(--ink);
+}
+
+.tldr p + p { margin-top: 14px; }
+.tldr strong { color: var(--accent); font-weight: 500; }
+
+.item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--rule);
+  align-items: start;
+}
+
+.item:last-child { border-bottom: none; }
+
+.lbl {
+  font-family: var(--font-plex-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.itemH {
+  font-family: var(--font-newsreader), ui-serif, Georgia, serif;
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 1.3;
+  color: var(--ink);
+  letter-spacing: -0.005em;
+  margin-bottom: 6px;
+}
+
+.itemP {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--soft);
+  max-width: 520px;
+}
+
+.stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-plex-mono), ui-monospace, monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 500;
+  white-space: nowrap;
+  padding-top: 4px;
+}
+
+.stat::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.statDone { color: var(--done); }
+.statDone::before { background: var(--done); }
+.statPartial { color: var(--partial); }
+.statPartial::before { background: var(--partial); }
+.statGap { color: var(--gap); }
+.statGap::before { background: var(--gap); }
+
+.issue {
+  display: grid;
+  grid-template-columns: 72px 1fr auto;
+  gap: 20px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--rule);
+  align-items: baseline;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s ease;
+}
+
+.issue:last-child { border-bottom: none; }
+.issue:hover { background: rgba(15, 92, 77, 0.025); }
+
+.issueNum {
+  font-family: var(--font-plex-mono), ui-monospace, monospace;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent);
+  letter-spacing: 0.04em;
+}
+
+.issueH {
+  font-family: var(--font-newsreader), ui-serif, Georgia, serif;
+  font-weight: 500;
+  font-size: 17px;
+  line-height: 1.3;
+  color: var(--ink);
+  margin-bottom: 4px;
+  letter-spacing: -0.005em;
+}
+
+.issueP {
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--soft);
+}
+
+.pri {
+  font-family: var(--font-plex-mono), ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  text-transform: uppercase;
+  padding: 3px 9px;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.pri0 { color: var(--gap); border-color: var(--gap); }
+.pri1 { color: var(--partial); border-color: var(--partial); }
+.pri2 { color: var(--muted); }
+
+.footer {
+  margin-top: 48px;
+  padding-top: 20px;
+  border-top: 1px solid var(--rule);
+  font-family: var(--font-plex-mono), ui-monospace, monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.footer a { color: var(--accent); text-decoration: none; }
+
+@media (max-width: 640px) {
+  .inner { padding: 36px 20px 64px; }
+  .h1 { font-size: 32px; }
+  .lede { font-size: 17px; }
+  .item { grid-template-columns: 1fr; }
+  .issue { grid-template-columns: 1fr; gap: 6px; }
+  .issueNum { font-size: 12px; }
+}

--- a/codebenders-dashboard/app/discovery/aascu/page.tsx
+++ b/codebenders-dashboard/app/discovery/aascu/page.tsx
@@ -1,0 +1,145 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { Newsreader, IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google"
+import styles from "./page.module.css"
+
+const newsreader = Newsreader({
+  variable: "--font-newsreader",
+  subsets: ["latin"],
+  weight: ["400", "500"],
+})
+
+const plexSans = IBM_Plex_Sans({
+  variable: "--font-plex-sans",
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+})
+
+const plexMono = IBM_Plex_Mono({
+  variable: "--font-plex-mono",
+  subsets: ["latin"],
+  weight: ["400", "500"],
+})
+
+export const metadata: Metadata = {
+  title: "AASCU Gap Analysis — Brief",
+  description: "Two-page condensation of the AASCU intermediary discovery session and the issues filed against the dashboard backlog.",
+}
+
+const ISSUE_BASE = "https://github.com/devcolor/codebenders-datathon/issues"
+
+const ISSUES: Array<{
+  num: number
+  title: string
+  desc: string
+  pri: "p0" | "p1" | "p2"
+}> = [
+  { num: 105, pri: "p0", title: "Metric definitions glossary with IPEDS / state cross-walks", desc: "Hover tooltips on every KPI · centralized /glossary page · markdown source-of-truth." },
+  { num: 106, pri: "p0", title: "Presentation-ready chart export (PNG / PDF)", desc: "Title, definition, source, date stamp baked in. Eliminates the manual Excel rebuild." },
+  { num: 107, pri: "p0", title: "Data lineage view — “where did this number come from”", desc: "Click any number → source rows, upload event, transformations, timestamps. Highest-leverage gap." },
+  { num: 108, pri: "p1", title: "AI Transparency Page", desc: "Per-model disclosure — features, training data, provider, data flow, retention. Reviewable independently." },
+  { num: 109, pri: "p1", title: "Sensitive-population safeguards", desc: "Per-institution feature exclusion · low-sample-size context warnings · audit log entries." },
+  { num: 110, pri: "p1", title: "Upload validation report — diff vs. last upload", desc: "Row-level errors, coercions, dedup decisions, dropped-campus flags. Readable by non-technical IR staff." },
+  { num: 111, pri: "p2", title: "Submission runbook generator", desc: "Capture what worked → printable runbook · replayable on new files · survives staff turnover." },
+  { num: 112, pri: "p2", title: "Datathon institution grouping (SIS + goal)", desc: "Operational artifact — cross-reference AASCU's SIS list with stated goals; output cohort matrix." },
+]
+
+const COVERAGE: Array<{
+  lbl: string
+  title: string
+  desc: string
+  status: "done" | "partial" | "gap"
+}> = [
+  { lbl: "A · Data accuracy", status: "partial", title: "Numbers don’t add up; PDP pulls from wrong dataset", desc: "Validation report on upload addresses the institutional side; PDP-side accuracy is out of scope." },
+  { lbl: "B · Definitions", status: "gap", title: "Metrics undefined in-context; mismatch with IPEDS / state", desc: "Tooltip primitive exists. Centralized glossary and cross-walks not yet built." },
+  { lbl: "C · Visualization", status: "done", title: "Wrong chart types in PDP; ours are sane", desc: "Recharts components, types chosen per metric. Done." },
+  { lbl: "C · Export", status: "partial", title: "CSV from dashboard; no presentation-ready chart export", desc: "CSV shipped (#15). PNG/PDF export with embedded definitions is the next step." },
+  { lbl: "D · FERPA", status: "done", title: "RBAC, audit log, FERPA-compliant identity resolution", desc: "Issues #67, #75, #77, #78 closed. FERPA basics covered." },
+  { lbl: "D · AI governance", status: "gap", title: "Transparency page, lineage view, sensitive-population safeguards", desc: "Methodology page exists. SHAP narrator in flight. Lineage and transparency disclosures unbuilt." },
+  { lbl: "E · Process", status: "partial", title: "Knowledge siloed; submission rituals vary per campus", desc: "Self-service upload (#86) helps. Runbook generator would close the loop." },
+]
+
+const statClass = (s: "done" | "partial" | "gap") =>
+  s === "done" ? styles.statDone : s === "partial" ? styles.statPartial : styles.statGap
+
+const priClass = (p: "p0" | "p1" | "p2") =>
+  p === "p0" ? styles.pri0 : p === "p1" ? styles.pri1 : styles.pri2
+
+export default function AASCUBriefPage() {
+  return (
+    <div className={`${newsreader.variable} ${plexSans.variable} ${plexMono.variable} ${styles.doc}`}>
+      <div className={styles.inner}>
+
+        <header className={styles.header}>
+          <div className={styles.kicker}>AASCU Discovery · Gap Analysis · Brief</div>
+          <h1 className={styles.h1}>What the tool already does, what it&rsquo;s missing, what to build next.</h1>
+          <p className={styles.lede}>
+            A two-page condensation of the AASCU intermediary discovery session and the eight issues filed against the codebenders-dashboard backlog.
+          </p>
+          <div className={styles.meta}>
+            <span><b>2026·04·29</b></span>
+            <span>2 intermediaries</span>
+            <span>21 min source</span>
+            <span>8 issues filed</span>
+          </div>
+        </header>
+
+        <section className={styles.section}>
+          <h2 className={styles.h2}>The take</h2>
+          <div className={styles.tldr}>
+            <p>
+              Intermediaries describe pain in three layers: <strong>PDP dashboard quality</strong> (charts, definitions, exports, accuracy), <strong>AI &amp; data governance</strong> (lineage, transparency, sensitive populations), and <strong>institutional process</strong> (knowledge silos, inconsistent submission rituals).
+            </p>
+            <p>
+              The tool already addresses meaningful parts of layer one and is in-flight on layer two via the SHAP narrator. The biggest unaddressed gaps are <strong>a definitions glossary, presentation-ready chart export, a data-lineage view, and AI transparency + sensitive-population safeguards</strong>.
+            </p>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.h2}>Pain × Coverage</h2>
+          {COVERAGE.map((row) => (
+            <div key={row.lbl} className={styles.item}>
+              <div>
+                <div className={styles.lbl}>{row.lbl}</div>
+                <h3 className={styles.itemH}>{row.title}</h3>
+                <p className={styles.itemP}>{row.desc}</p>
+              </div>
+              <span className={`${styles.stat} ${statClass(row.status)}`}>
+                {row.status === "done" ? "Done" : row.status === "partial" ? "Partial" : "Gap"}
+              </span>
+            </div>
+          ))}
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.h2}>Issues filed (#105 — #112)</h2>
+          {ISSUES.map((iss) => (
+            <a
+              key={iss.num}
+              className={styles.issue}
+              href={`${ISSUE_BASE}/${iss.num}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <div className={styles.issueNum}>#{iss.num}</div>
+              <div>
+                <h3 className={styles.issueH}>{iss.title}</h3>
+                <p className={styles.issueP}>{iss.desc}</p>
+              </div>
+              <span className={`${styles.pri} ${priClass(iss.pri)}`}>{iss.pri.toUpperCase()}</span>
+            </a>
+          ))}
+        </section>
+
+        <footer className={styles.footer}>
+          <span>Brief · Bishop State CC · Codebenders Datathon</span>
+          <span>
+            Full report → <Link href="/discovery/aascu/full">aascu / full</Link>
+          </span>
+        </footer>
+
+      </div>
+    </div>
+  )
+}

--- a/codebenders-dashboard/components/nav-header.tsx
+++ b/codebenders-dashboard/components/nav-header.tsx
@@ -17,6 +17,7 @@ const NAV_LINKS: Array<{ href: string; label: string; roles?: Role[] }> = [
   { href: "/courses",   label: "Courses"   },
   { href: "/students",  label: "Students"  },
   { href: "/query",     label: "Query"     },
+  { href: "/discovery/aascu", label: "Discovery", roles: ["admin", "ir", "leadership"] },
   { href: "/admin/upload", label: "Admin", roles: ["admin", "ir"] },
 ]
 

--- a/codebenders-dashboard/lib/roles.ts
+++ b/codebenders-dashboard/lib/roles.ts
@@ -13,6 +13,7 @@ export const ROUTE_PERMISSIONS: Array<{ prefix: string; roles: Role[] }> = [
   { prefix: "/api/query-history/export", roles: ["admin", "ir"] },
   { prefix: "/admin",                    roles: ["admin", "ir"] },
   { prefix: "/api/admin",               roles: ["admin", "ir"] },
+  { prefix: "/discovery",                roles: ["admin", "ir", "leadership"] },
 ]
 
 export function canAccess(pathname: string, role: Role): boolean {

--- a/docs/aascu_gap_analysis.html
+++ b/docs/aascu_gap_analysis.html
@@ -1,0 +1,946 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>AASCU Intermediary Discovery — Gap Analysis</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --paper:#f5efe4;
+    --paper-deep:#ece3d2;
+    --ink:#1a1714;
+    --ink-soft:#3b342c;
+    --muted:#857a68;
+    --rule:#d6cbb5;
+    --accent:#b8531a;          /* burnt sienna */
+    --accent-deep:#8a3d12;
+    --done:#4f6539;            /* sage */
+    --partial:#a87f1f;         /* mustard */
+    --gap:#8b2f2a;             /* terracotta */
+    --p0:#8b2f2a;
+    --p1:#a87f1f;
+    --p2:#5d6b76;              /* slate */
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html,body{background:var(--paper);color:var(--ink);font-family:"IBM Plex Sans",ui-sans-serif,system-ui,sans-serif;font-weight:400;line-height:1.55;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+  body{
+    background-image:
+      radial-gradient(circle at 20% 10%, rgba(184,83,26,0.04), transparent 40%),
+      radial-gradient(circle at 80% 80%, rgba(26,23,20,0.05), transparent 50%),
+      url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='140' height='140'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.10 0 0 0 0 0.09 0 0 0 0 0.08 0 0 0 0.04 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+    background-attachment:fixed;
+    min-height:100vh;
+  }
+  .doc{
+    max-width:1180px;
+    margin:0 auto;
+    padding:64px 56px 120px;
+  }
+
+  /* —— masthead —— */
+  .mast{
+    border-top:2px solid var(--ink);
+    border-bottom:1px solid var(--ink);
+    padding:18px 0 22px;
+    display:grid;
+    grid-template-columns:1fr auto;
+    align-items:end;
+    gap:24px;
+    animation:fadeUp .8s ease-out both;
+  }
+  .mast .lockup{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:11px;
+    letter-spacing:.18em;
+    text-transform:uppercase;
+    color:var(--ink-soft);
+  }
+  .mast .lockup b{color:var(--accent);font-weight:500}
+  .mast .meta{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10.5px;
+    letter-spacing:.16em;
+    text-transform:uppercase;
+    color:var(--muted);
+    text-align:right;
+    line-height:1.7;
+  }
+
+  /* —— hero —— */
+  .hero{
+    padding:80px 0 64px;
+    border-bottom:1px solid var(--rule);
+    position:relative;
+  }
+  .hero .eyebrow{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:11px;
+    letter-spacing:.22em;
+    text-transform:uppercase;
+    color:var(--accent);
+    margin-bottom:28px;
+    animation:fadeUp .9s .1s ease-out both;
+  }
+  .hero h1{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 144,"SOFT" 30;
+    font-weight:340;
+    font-size:clamp(48px,7.2vw,108px);
+    line-height:.94;
+    letter-spacing:-0.025em;
+    color:var(--ink);
+    margin-bottom:32px;
+    animation:fadeUp 1s .15s ease-out both;
+  }
+  .hero h1 em{
+    font-style:italic;
+    font-weight:300;
+    color:var(--accent);
+    font-variation-settings:"opsz" 144,"SOFT" 80;
+  }
+  .hero .lede{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 36;
+    font-weight:330;
+    font-size:clamp(20px,1.7vw,24px);
+    line-height:1.45;
+    color:var(--ink-soft);
+    max-width:780px;
+    animation:fadeUp 1s .25s ease-out both;
+  }
+  .hero .strip{
+    margin-top:56px;
+    display:grid;
+    grid-template-columns:repeat(4,1fr);
+    gap:0;
+    border-top:1px solid var(--rule);
+    animation:fadeUp 1s .35s ease-out both;
+  }
+  .hero .strip > div{
+    padding:18px 20px 4px 0;
+    border-right:1px solid var(--rule);
+  }
+  .hero .strip > div:last-child{border-right:none;padding-right:0}
+  .hero .strip dt{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10px;
+    letter-spacing:.2em;
+    text-transform:uppercase;
+    color:var(--muted);
+    margin-bottom:8px;
+  }
+  .hero .strip dd{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 60;
+    font-weight:340;
+    font-size:34px;
+    line-height:1;
+    color:var(--ink);
+    letter-spacing:-0.01em;
+  }
+  .hero .strip dd small{
+    display:block;
+    font-family:"IBM Plex Sans";
+    font-size:11px;
+    letter-spacing:.04em;
+    color:var(--muted);
+    margin-top:8px;
+    font-weight:400;
+  }
+
+  /* —— section scaffolding —— */
+  section.chapter{
+    padding:88px 0 24px;
+    border-bottom:1px solid var(--rule);
+  }
+  section.chapter:last-of-type{border-bottom:none}
+  .chap-head{
+    display:grid;
+    grid-template-columns:120px 1fr;
+    gap:48px;
+    margin-bottom:56px;
+    align-items:start;
+  }
+  .chap-num{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 144,"SOFT" 0;
+    font-weight:300;
+    font-size:96px;
+    line-height:.85;
+    color:var(--accent);
+    letter-spacing:-0.04em;
+  }
+  .chap-num span{
+    display:block;
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10px;
+    letter-spacing:.22em;
+    text-transform:uppercase;
+    color:var(--muted);
+    margin-top:14px;
+  }
+  .chap-title{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 60;
+    font-weight:360;
+    font-size:clamp(32px,3.6vw,52px);
+    line-height:1.05;
+    letter-spacing:-0.02em;
+    color:var(--ink);
+    max-width:780px;
+  }
+  .chap-title em{font-style:italic;font-weight:300;color:var(--accent);font-variation-settings:"opsz" 60,"SOFT" 80}
+  .chap-kicker{
+    font-family:"IBM Plex Sans";
+    font-size:15px;
+    line-height:1.6;
+    color:var(--ink-soft);
+    margin-top:18px;
+    max-width:680px;
+  }
+
+  /* —— pain point grid —— */
+  .pains{
+    display:grid;
+    grid-template-columns:repeat(2,1fr);
+    gap:1px;
+    background:var(--rule);
+    border:1px solid var(--rule);
+  }
+  .pain{
+    background:var(--paper);
+    padding:32px 30px 36px;
+    position:relative;
+  }
+  .pain .tag{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10px;
+    letter-spacing:.2em;
+    text-transform:uppercase;
+    color:var(--accent);
+    margin-bottom:14px;
+    display:flex;
+    gap:10px;
+    align-items:center;
+  }
+  .pain .tag::before{
+    content:"";
+    width:14px;height:1px;background:var(--accent);
+  }
+  .pain h3{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 36;
+    font-weight:380;
+    font-size:23px;
+    line-height:1.2;
+    color:var(--ink);
+    margin-bottom:16px;
+    letter-spacing:-0.01em;
+  }
+  .pain ul{list-style:none;padding:0;margin:0}
+  .pain li{
+    position:relative;
+    padding-left:18px;
+    margin-bottom:10px;
+    font-size:14.5px;
+    line-height:1.55;
+    color:var(--ink-soft);
+  }
+  .pain li::before{
+    content:"";
+    position:absolute;
+    left:0;top:.65em;
+    width:6px;height:1px;background:var(--ink-soft);
+  }
+  .pain li strong{color:var(--ink);font-weight:500}
+
+  /* —— pull quote —— */
+  .pq{
+    margin:64px auto;
+    max-width:880px;
+    padding:0 24px;
+    text-align:center;
+  }
+  .pq blockquote{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 144,"SOFT" 100;
+    font-style:italic;
+    font-weight:320;
+    font-size:clamp(26px,3vw,40px);
+    line-height:1.25;
+    color:var(--ink);
+    letter-spacing:-0.015em;
+  }
+  .pq blockquote::before{
+    content:"\201C";
+    display:block;
+    font-size:96px;
+    line-height:.5;
+    color:var(--accent);
+    margin-bottom:8px;
+    opacity:.7;
+  }
+  .pq cite{
+    display:block;
+    margin-top:24px;
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-style:normal;
+    font-size:11px;
+    letter-spacing:.2em;
+    text-transform:uppercase;
+    color:var(--muted);
+  }
+
+  /* —— coverage list (replaces table) —— */
+  .coverage{
+    display:grid;
+    grid-template-columns:1fr;
+    gap:0;
+  }
+  .row{
+    display:grid;
+    grid-template-columns:140px 1.2fr 1.4fr 0.7fr;
+    gap:32px;
+    padding:22px 0;
+    border-bottom:1px solid var(--rule);
+    align-items:start;
+  }
+  .row:first-child{border-top:1px solid var(--ink)}
+  .row.head{
+    padding:14px 0;
+    border-bottom:1px solid var(--ink);
+  }
+  .row.head > div{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10px;
+    letter-spacing:.2em;
+    text-transform:uppercase;
+    color:var(--muted);
+  }
+  .row .pp{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:11px;
+    letter-spacing:.16em;
+    text-transform:uppercase;
+    color:var(--accent);
+  }
+  .row .name{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 24;
+    font-weight:400;
+    font-size:18px;
+    line-height:1.3;
+    color:var(--ink);
+    letter-spacing:-0.005em;
+  }
+  .row .ev{
+    font-size:13.5px;
+    line-height:1.55;
+    color:var(--ink-soft);
+  }
+  .row .ev code{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:12px;
+    background:var(--paper-deep);
+    padding:1px 6px;
+    border-radius:2px;
+    color:var(--ink);
+  }
+  .stat{
+    display:inline-flex;
+    align-items:center;
+    gap:8px;
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:11px;
+    letter-spacing:.16em;
+    text-transform:uppercase;
+    font-weight:500;
+  }
+  .stat::before{
+    content:"";
+    width:8px;height:8px;border-radius:50%;
+    flex-shrink:0;
+  }
+  .stat.done{color:var(--done)} .stat.done::before{background:var(--done)}
+  .stat.partial{color:var(--partial)} .stat.partial::before{background:var(--partial)}
+  .stat.gap{color:var(--gap)} .stat.gap::before{background:var(--gap)}
+
+  /* —— issue cards —— */
+  .tier{
+    margin-bottom:56px;
+  }
+  .tier-head{
+    display:flex;
+    align-items:baseline;
+    gap:24px;
+    margin-bottom:28px;
+    padding-bottom:14px;
+    border-bottom:1px solid var(--ink);
+  }
+  .tier-pill{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:11px;
+    font-weight:500;
+    letter-spacing:.18em;
+    padding:6px 14px;
+    border-radius:2px;
+    color:var(--paper);
+  }
+  .tier-pill.p0{background:var(--p0)}
+  .tier-pill.p1{background:var(--p1)}
+  .tier-pill.p2{background:var(--p2)}
+  .tier-h{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 36;
+    font-weight:370;
+    font-size:24px;
+    color:var(--ink);
+    letter-spacing:-0.01em;
+  }
+  .tier-h em{font-style:italic;color:var(--muted);font-weight:330}
+  .cards{
+    display:grid;
+    grid-template-columns:repeat(3,1fr);
+    gap:1px;
+    background:var(--rule);
+    border:1px solid var(--rule);
+  }
+  .card{
+    background:var(--paper);
+    padding:28px 26px 32px;
+    display:flex;
+    flex-direction:column;
+    transition:background .25s ease, transform .25s ease;
+  }
+  .card:hover{background:var(--paper-deep);transform:translateY(-2px)}
+  .card .num{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10.5px;
+    letter-spacing:.18em;
+    color:var(--muted);
+    text-transform:uppercase;
+    margin-bottom:14px;
+    display:flex;
+    justify-content:space-between;
+  }
+  .card .num b{color:var(--ink);font-weight:500;letter-spacing:.1em}
+  .card h4{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 30;
+    font-weight:400;
+    font-size:21px;
+    line-height:1.2;
+    letter-spacing:-0.01em;
+    color:var(--ink);
+    margin-bottom:14px;
+  }
+  .card .pp-tag{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10px;
+    letter-spacing:.2em;
+    text-transform:uppercase;
+    color:var(--accent);
+    margin-bottom:10px;
+  }
+  .card p{
+    font-size:14px;
+    line-height:1.6;
+    color:var(--ink-soft);
+    margin-bottom:auto;
+  }
+  .card .link{
+    margin-top:20px;
+    padding-top:16px;
+    border-top:1px dotted var(--rule);
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:11px;
+    letter-spacing:.14em;
+    text-transform:uppercase;
+    color:var(--accent);
+    text-decoration:none;
+    display:inline-flex;
+    align-items:center;
+    gap:8px;
+  }
+  .card .link:hover{color:var(--accent-deep)}
+  .card .link::after{content:"\2192"}
+
+  /* —— exec summary —— */
+  .summary{
+    display:grid;
+    grid-template-columns:1fr 2fr;
+    gap:64px;
+    align-items:start;
+  }
+  .summary aside{
+    border-top:2px solid var(--ink);
+    padding-top:18px;
+  }
+  .summary aside h5{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10px;
+    letter-spacing:.22em;
+    text-transform:uppercase;
+    color:var(--muted);
+    margin-bottom:18px;
+  }
+  .summary aside ul{list-style:none;padding:0}
+  .summary aside li{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 24;
+    font-size:18px;
+    line-height:1.35;
+    padding:10px 0;
+    border-bottom:1px solid var(--rule);
+    color:var(--ink);
+  }
+  .summary aside li::before{
+    content:attr(data-n);
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10px;
+    letter-spacing:.2em;
+    color:var(--accent);
+    margin-right:14px;
+    vertical-align:2px;
+  }
+  .summary .body p{
+    font-family:"Fraunces",ui-serif,Georgia,serif;
+    font-variation-settings:"opsz" 24;
+    font-weight:340;
+    font-size:21px;
+    line-height:1.55;
+    color:var(--ink);
+    margin-bottom:18px;
+    letter-spacing:-0.005em;
+  }
+  .summary .body p strong{color:var(--accent);font-weight:450}
+  .summary .body p em{font-style:italic;color:var(--ink-soft)}
+
+  /* —— scope footer —— */
+  .scope{
+    margin-top:48px;
+    padding:32px 0 0;
+    border-top:1px solid var(--rule);
+    display:grid;
+    grid-template-columns:200px 1fr;
+    gap:48px;
+  }
+  .scope h6{
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10px;
+    letter-spacing:.22em;
+    text-transform:uppercase;
+    color:var(--muted);
+  }
+  .scope ul{list-style:none;padding:0;display:grid;grid-template-columns:repeat(3,1fr);gap:24px}
+  .scope li{
+    font-size:13.5px;
+    line-height:1.5;
+    color:var(--ink-soft);
+    padding-left:14px;
+    position:relative;
+  }
+  .scope li::before{
+    content:"\00d7";
+    position:absolute;left:0;top:0;
+    color:var(--gap);font-weight:500;
+  }
+
+  /* —— colophon —— */
+  footer.colophon{
+    margin-top:96px;
+    padding-top:24px;
+    border-top:2px solid var(--ink);
+    display:grid;
+    grid-template-columns:1fr auto;
+    gap:24px;
+    font-family:"JetBrains Mono",ui-monospace,monospace;
+    font-size:10.5px;
+    letter-spacing:.18em;
+    text-transform:uppercase;
+    color:var(--muted);
+  }
+  footer.colophon b{color:var(--ink);font-weight:500}
+
+  @keyframes fadeUp{
+    from{opacity:0;transform:translateY(14px)}
+    to{opacity:1;transform:translateY(0)}
+  }
+
+  /* —— responsive —— */
+  @media (max-width:920px){
+    .doc{padding:32px 22px 80px}
+    .hero h1{font-size:54px}
+    .hero .strip{grid-template-columns:repeat(2,1fr)}
+    .hero .strip > div{padding:18px 16px 4px 0}
+    .hero .strip > div:nth-child(2n){border-right:none}
+    .hero .strip > div:nth-child(-n+2){border-bottom:1px solid var(--rule)}
+    .chap-head{grid-template-columns:1fr;gap:20px}
+    .chap-num{font-size:64px}
+    .pains{grid-template-columns:1fr}
+    .row{grid-template-columns:1fr;gap:8px;padding:18px 0}
+    .summary{grid-template-columns:1fr;gap:36px}
+    .cards{grid-template-columns:1fr}
+    .scope{grid-template-columns:1fr;gap:18px}
+    .scope ul{grid-template-columns:1fr}
+  }
+</style>
+</head>
+<body>
+<div class="doc">
+
+  <header class="mast">
+    <div class="lockup">Codebenders Datathon · <b>Discovery Report №&nbsp;01</b> · Bishop&nbsp;State&nbsp;CC</div>
+    <div class="meta">
+      Filed&nbsp;2026·04·29<br>
+      Source: 21-min&nbsp;recording + notes<br>
+      Status: Stakeholder review
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="eyebrow">AASCU Intermediary Discovery — Gap Analysis</div>
+    <h1>The data they have <em>isn't</em> the data they trust.</h1>
+    <p class="lede">
+      Two AASCU intermediaries described, in their own words, why the Postsecondary Data Partnership dashboard fails the institutions they support — and where a tool built around <em>provable</em>, <em>presentable</em>, <em>governed</em> outputs would land.
+    </p>
+    <dl class="strip">
+      <div><dt>Recording</dt><dd>20:58<small>minutes of testimony</small></dd></div>
+      <div><dt>Voices</dt><dd>2<small>intermediaries · IR + data&#8209;eng</small></dd></div>
+      <div><dt>Pain themes</dt><dd>6<small>mapped across stack</small></dd></div>
+      <div><dt>Issues filed</dt><dd>8<small>#105 — #112</small></dd></div>
+    </dl>
+  </section>
+
+  <!-- ——— EXECUTIVE SUMMARY ——— -->
+  <section class="chapter">
+    <div class="chap-head">
+      <div class="chap-num">01<span>Executive summary</span></div>
+      <div>
+        <h2 class="chap-title">A tool worth adopting is one that <em>institutions can defend</em> — to legal, to leadership, to themselves.</h2>
+        <p class="chap-kicker">The intermediaries don't need another dashboard. They need outputs they can present upward, prove the provenance of, and govern responsibly when sensitive student populations are involved.</p>
+      </div>
+    </div>
+    <div class="summary">
+      <aside>
+        <h5>Three layers of pain</h5>
+        <ul>
+          <li data-n="01">PDP dashboard quality</li>
+          <li data-n="02">AI &amp; data governance</li>
+          <li data-n="03">Institutional process</li>
+        </ul>
+      </aside>
+      <div class="body">
+        <p>Two AASCU intermediaries described pain in three layers: <strong>PDP dashboard quality</strong> — inaccurate cohort numbers, buried definitions, wrong chart types, no data export — forcing IR staff into manual Excel rebuilds; <strong>AI/governance requirements</strong> — FERPA-plus expectations including data lineage, transparency, and explicit safeguards for sensitive student populations; and <strong>institutional process gaps</strong> — submission knowledge that lives with one person and varies wildly across campuses.</p>
+        <p>Our tool already addresses a meaningful share of layer one — CSV export, sane chart types, NLQ, methodology page — and is in-flight on layer two via the SHAP-narrator work. The biggest unaddressed gaps are <em>a definitions glossary with IPEDS / state-compliance cross-walks, presentation-ready chart export, a data-lineage view that proves where each number came from, and AI transparency + sensitive-population safeguards as a precondition for institutional adoption.</em></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ——— PAIN POINTS ——— -->
+  <section class="chapter">
+    <div class="chap-head">
+      <div class="chap-num">02<span>What we heard</span></div>
+      <div>
+        <h2 class="chap-title">Six themes — <em>raised independently</em> by both intermediaries.</h2>
+        <p class="chap-kicker">Andres (IR-focused) and Dr. Prateek (data-engineering-focused) emphasized different layers, but converged on a common diagnosis: institutions can't trust, can't present, and can't govern what PDP gives them today.</p>
+      </div>
+    </div>
+
+    <div class="pains">
+      <div class="pain">
+        <div class="tag">A · Data accuracy &amp; trust</div>
+        <h3>Numbers that don't add up</h3>
+        <ul>
+          <li>Incorrect cohort sizes; campuses missing from dashboard dropdowns.</li>
+          <li>Dashboard <strong>pulls from the wrong dataset</strong> intermittently.</li>
+          <li>Submission-time processing corrupts otherwise-clean institutional data.</li>
+          <li>No cross-source verification — intermediaries and institutions take each other's word.</li>
+        </ul>
+      </div>
+
+      <div class="pain">
+        <div class="tag">B · Definitions &amp; terminology</div>
+        <h3>The glossary that isn't there</h3>
+        <ul>
+          <li>"Completion at 3/4/5 years" and retention metrics undefined in-context.</li>
+          <li>Definitions live in <strong>external documentation</strong>, not the dashboard.</li>
+          <li>Terms diverge from IPEDS and state-compliance vocabulary IR staff already use.</li>
+        </ul>
+      </div>
+
+      <div class="pain">
+        <div class="tag">C · Visualization &amp; export</div>
+        <h3>Charts you can't show your boss</h3>
+        <ul>
+          <li>Wrong chart types — line graph for independent cohorts where bar is correct.</li>
+          <li>Charts <strong>not presentation-ready</strong>; IR staff rebuild in Excel by hand.</li>
+          <li>No data download from dashboard. Analysis-ready file is a <strong>$20K paywall</strong>.</li>
+        </ul>
+      </div>
+
+      <div class="pain">
+        <div class="tag">D · AI &amp; governance</div>
+        <h3>FERPA is the floor, not the ceiling</h3>
+        <ul>
+          <li>"Weaponizing data" risk to under-resourced campuses via context-free AI inference.</li>
+          <li>Sensitive populations — immigrant, undocumented, public-aid — need explicit care.</li>
+          <li>Demand for full <strong>data lineage</strong>, model transparency, storage disclosure.</li>
+        </ul>
+      </div>
+
+      <div class="pain">
+        <div class="tag">E · Institutional process</div>
+        <h3>One person knows; one person retires</h3>
+        <ul>
+          <li>Submission knowledge silos with one IR staffer per institution.</li>
+          <li>Each campus has wildly different submission rituals — some delist + re-upload everything every cycle.</li>
+          <li>"Best edit resolution" loses to <strong>people-and-process bottlenecks</strong>.</li>
+        </ul>
+      </div>
+
+      <div class="pain">
+        <div class="tag">F · Datathon coordination</div>
+        <h3>Group by goal, not just SIS</h3>
+        <ul>
+          <li>AASCU has SIS-by-institution list — can rank by commonality or by need.</li>
+          <li>Last datathon: wildly different institutional incomes ate most of the day.</li>
+          <li>Recommend grouping by <strong>shared SIS + shared goal</strong> (e.g., advising).</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <div class="pq">
+    <blockquote>
+      Why on earth would they invest any time in learning this new tool?
+    </blockquote>
+    <cite>— Intermediary, on PDP's compounding friction · 21-min recording, 03:42</cite>
+  </div>
+
+  <!-- ——— TOOL COVERAGE ——— -->
+  <section class="chapter">
+    <div class="chap-head">
+      <div class="chap-num">03<span>What the tool already does</span></div>
+      <div>
+        <h2 class="chap-title">A meaningful share of the pain is <em>already addressed</em> in `codebenders-dashboard`.</h2>
+        <p class="chap-kicker">Mapping each pain point to the closed PRs and shipped components. Status reflects the state of the codebase as of this report.</p>
+      </div>
+    </div>
+
+    <div class="coverage">
+      <div class="row head">
+        <div>Pain point</div>
+        <div>Capability</div>
+        <div>Evidence</div>
+        <div>Status</div>
+      </div>
+
+      <div class="row">
+        <div class="pp">C · Export</div>
+        <div class="name">CSV export wired into dashboard</div>
+        <div class="ev"><code>components/export-button.tsx</code> · issue&nbsp;#15</div>
+        <div><span class="stat done">Done</span></div>
+      </div>
+
+      <div class="row">
+        <div class="pp">C · Visualization</div>
+        <div class="name">Recharts components, types chosen per metric</div>
+        <div class="ev"><code>retention-risk-chart.tsx</code>, <code>risk-alert-chart.tsx</code>, <code>readiness-assessment-chart.tsx</code></div>
+        <div><span class="stat done">Done</span></div>
+      </div>
+
+      <div class="row">
+        <div class="pp">B · Definitions</div>
+        <div class="name">Tooltip primitive exists; no centralized glossary yet</div>
+        <div class="ev"><code>components/info-popover.tsx</code></div>
+        <div><span class="stat partial">Partial</span></div>
+      </div>
+
+      <div class="row">
+        <div class="pp">D · Methodology</div>
+        <div class="name">How predictions are made — surfaced in-app</div>
+        <div class="ev"><code>app/methodology/</code> route</div>
+        <div><span class="stat done">Done</span></div>
+      </div>
+
+      <div class="row">
+        <div class="pp">D · FERPA</div>
+        <div class="name">RBAC, audit log, FERPA-compliant identity resolution</div>
+        <div class="ev">Issues #67, #75, #77, #78 (closed)</div>
+        <div><span class="stat done">Done</span></div>
+      </div>
+
+      <div class="row">
+        <div class="pp">D · Automation</div>
+        <div class="name">Self-service upload (PDP, AR, student, course)</div>
+        <div class="ev">Issue #86 (closed) · <code>components/upload/</code></div>
+        <div><span class="stat done">Done</span></div>
+      </div>
+
+      <div class="row">
+        <div class="pp">D · Explainability</div>
+        <div class="name">SHAP narrator — fine-tuning epic in progress</div>
+        <div class="ev">Issues #97 — #103 · branch <code>fine-tuning/97-shap-narrator-task-type</code></div>
+        <div><span class="stat partial">In flight</span></div>
+      </div>
+
+      <div class="row">
+        <div class="pp">A · Validation</div>
+        <div class="name">Upload exists; human-readable validation report missing</div>
+        <div class="ev">Addressed by new issue #110</div>
+        <div><span class="stat partial">Partial</span></div>
+      </div>
+
+      <div class="row">
+        <div class="pp">C · Filtering</div>
+        <div class="name">By cohort, term, demographic, credential type</div>
+        <div class="ev">Issues #66, #81 (closed)</div>
+        <div><span class="stat done">Done</span></div>
+      </div>
+
+      <div class="row">
+        <div class="pp">C · Query</div>
+        <div class="name">Natural-language query against the data</div>
+        <div class="ev"><code>lib/prompt-analyzer.ts</code> · issues #17, #61, #88, #90</div>
+        <div><span class="stat done">Done</span></div>
+      </div>
+
+      <div class="row">
+        <div class="pp">E · Knowledge</div>
+        <div class="name">Self-service upload reduces single-person dependency</div>
+        <div class="ev">In-app submission runbook missing — addressed by #111</div>
+        <div><span class="stat partial">Partial</span></div>
+      </div>
+    </div>
+  </section>
+
+  <div class="pq">
+    <blockquote>
+      I just went by each data point and copied that number into the Excel spreadsheet.
+    </blockquote>
+    <cite>— Dr. Prateek, on rebuilding PDP outputs by hand · 04:58</cite>
+  </div>
+
+  <!-- ——— GAPS / ISSUES ——— -->
+  <section class="chapter">
+    <div class="chap-head">
+      <div class="chap-num">04<span>Gaps — issues filed</span></div>
+      <div>
+        <h2 class="chap-title">Eight issues, three priority tiers, one through-line: <em>provable, presentable, governed</em>.</h2>
+        <p class="chap-kicker">Each issue links back to a specific quote or recurring complaint from the discovery session. Out-of-scope items are listed at the end and intentionally not filed.</p>
+      </div>
+    </div>
+
+    <!-- P0 -->
+    <div class="tier">
+      <div class="tier-head">
+        <span class="tier-pill p0">P0 · Differentiators</span>
+        <h3 class="tier-h">Match the loudest complaints. <em>Datathon-eligible.</em></h3>
+      </div>
+      <div class="cards">
+        <article class="card">
+          <div class="num"><span>Issue</span><b>#105</b></div>
+          <div class="pp-tag">Pain B · Definitions</div>
+          <h4>Metric definitions glossary with IPEDS &amp; state-compliance cross-walks</h4>
+          <p>Every KPI surfaces a tooltip with PDP, IPEDS, and state-compliance equivalents. Centralized <code>/glossary</code> page indexed by metric. Markdown source-of-truth, versioned with the code.</p>
+          <a class="link" href="https://github.com/devcolor/codebenders-datathon/issues/105">Open issue</a>
+        </article>
+        <article class="card">
+          <div class="num"><span>Issue</span><b>#106</b></div>
+          <div class="pp-tag">Pain C · Export</div>
+          <h4>Presentation-ready chart export (PNG / PDF)</h4>
+          <p>Every chart exports as a polished image with title, definition, source, and date stamp baked in. Eliminates the manual Excel-rebuild workflow IR staff perform daily.</p>
+          <a class="link" href="https://github.com/devcolor/codebenders-datathon/issues/106">Open issue</a>
+        </article>
+        <article class="card">
+          <div class="num"><span>Issue</span><b>#107</b></div>
+          <div class="pp-tag">Pain A + D · Lineage</div>
+          <h4>Data lineage view — "where did this number come from"</h4>
+          <p>Click any number → see source rows, upload event, transformations, and timestamps. The single highest-leverage gap from the session: directly answers trust + governance + differentiation in one feature.</p>
+          <a class="link" href="https://github.com/devcolor/codebenders-datathon/issues/107">Open issue</a>
+        </article>
+      </div>
+    </div>
+
+    <!-- P1 -->
+    <div class="tier">
+      <div class="tier-head">
+        <span class="tier-pill p1">P1 · Governance hardening</span>
+        <h3 class="tier-h">Table-stakes for institutional adoption.</h3>
+      </div>
+      <div class="cards">
+        <article class="card">
+          <div class="num"><span>Issue</span><b>#108</b></div>
+          <div class="pp-tag">Pain D · Transparency</div>
+          <h4>AI Transparency Page</h4>
+          <p>Per-model disclosure: features used, training data source, homegrown vs. third-party, where data flows when invoked, retention policy. Reviewable independently by institutional IT &amp; legal.</p>
+          <a class="link" href="https://github.com/devcolor/codebenders-datathon/issues/108">Open issue</a>
+        </article>
+        <article class="card">
+          <div class="num"><span>Issue</span><b>#109</b></div>
+          <div class="pp-tag">Pain D · Sensitive populations</div>
+          <h4>Sensitive-population safeguards</h4>
+          <p>Per-institution feature-exclusion lists. Context warnings on small sub-populations. Audit log entries for any query touching flagged groups. Demoable, not just claimed.</p>
+          <a class="link" href="https://github.com/devcolor/codebenders-datathon/issues/109">Open issue</a>
+        </article>
+        <article class="card">
+          <div class="num"><span>Issue</span><b>#110</b></div>
+          <div class="pp-tag">Pain A + E · Validation</div>
+          <h4>Upload validation report — diff vs. last upload</h4>
+          <p>Row-level errors, field coercions, dedup decisions, anomaly flags ("3 campuses dropped from this upload"). Readable by non-technical IR staff. Survives the "person retires" scenario.</p>
+          <a class="link" href="https://github.com/devcolor/codebenders-datathon/issues/110">Open issue</a>
+        </article>
+      </div>
+    </div>
+
+    <!-- P2 -->
+    <div class="tier">
+      <div class="tier-head">
+        <span class="tier-pill p2">P2 · Process &amp; institutional fit</span>
+        <h3 class="tier-h">Lower urgency, higher institutional gratitude.</h3>
+      </div>
+      <div class="cards" style="grid-template-columns:repeat(2,1fr)">
+        <article class="card">
+          <div class="num"><span>Issue</span><b>#111</b></div>
+          <div class="pp-tag">Pain E · Process</div>
+          <h4>Submission runbook generator</h4>
+          <p>Tool records the upload steps + field mappings that worked, then generates a printable runbook so a successor can replicate without tribal knowledge. Replayable on new files.</p>
+          <a class="link" href="https://github.com/devcolor/codebenders-datathon/issues/111">Open issue</a>
+        </article>
+        <article class="card">
+          <div class="num"><span>Issue</span><b>#112</b></div>
+          <div class="pp-tag">Pain F · Datathon coordination</div>
+          <h4>Institution-grouping helper — shared SIS + shared goal</h4>
+          <p>Operational artifact, not a user feature: cross-reference AASCU's SIS list with stated institutional goals; output a candidate cohort matrix for the fall datathon.</p>
+          <a class="link" href="https://github.com/devcolor/codebenders-datathon/issues/112">Open issue</a>
+        </article>
+      </div>
+    </div>
+
+    <div class="scope">
+      <h6>Intentionally<br>out of scope</h6>
+      <ul>
+        <li>PDP-side cohort accuracy and dropdown completeness — that's PDP's bug to fix; we shouldn't build around it.</li>
+        <li>The $20K analysis-ready file paywall — pricing decision by PDP; not addressable here.</li>
+        <li>Vendor over-promising on "full automation" — competitive-positioning concern, not a feature.</li>
+      </ul>
+    </div>
+  </section>
+
+  <footer class="colophon">
+    <div>
+      <b>AASCU Intermediary Discovery</b> · Gap Analysis<br>
+      Set in Fraunces &amp; IBM Plex Sans · Filed 2026·04·29
+    </div>
+    <div>
+      Codebenders&nbsp;Datathon ·&nbsp;<b>Bishop&nbsp;State&nbsp;CC</b>
+    </div>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/aascu_gap_analysis_simple.html
+++ b/docs/aascu_gap_analysis_simple.html
@@ -1,0 +1,411 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>AASCU Gap Analysis — Brief</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,500&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#fafaf7;
+    --ink:#15181a;
+    --soft:#4a4f53;
+    --muted:#7d8489;
+    --rule:#e3e1da;
+    --accent:#0f5c4d;     /* deep forest */
+    --accent-soft:#e8efe9;
+    --done:#0f5c4d;
+    --partial:#9a6d12;
+    --gap:#8b3a3a;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html,body{
+    background:var(--bg);
+    color:var(--ink);
+    font-family:"IBM Plex Sans",ui-sans-serif,system-ui,sans-serif;
+    line-height:1.55;
+    -webkit-font-smoothing:antialiased;
+  }
+  .doc{
+    max-width:760px;
+    margin:0 auto;
+    padding:56px 32px 96px;
+  }
+
+  /* —— header —— */
+  header{
+    padding-bottom:32px;
+    border-bottom:1px solid var(--ink);
+    margin-bottom:48px;
+  }
+  .kicker{
+    font-family:"IBM Plex Mono",ui-monospace,monospace;
+    font-size:11px;
+    letter-spacing:.16em;
+    text-transform:uppercase;
+    color:var(--accent);
+    margin-bottom:18px;
+  }
+  h1{
+    font-family:"Newsreader",ui-serif,Georgia,serif;
+    font-weight:400;
+    font-size:42px;
+    line-height:1.1;
+    letter-spacing:-0.02em;
+    color:var(--ink);
+    margin-bottom:14px;
+  }
+  .lede{
+    font-family:"Newsreader",ui-serif,Georgia,serif;
+    font-weight:400;
+    font-size:19px;
+    line-height:1.5;
+    color:var(--soft);
+    max-width:620px;
+  }
+  .meta{
+    margin-top:24px;
+    display:flex;
+    gap:24px;
+    flex-wrap:wrap;
+    font-family:"IBM Plex Mono",ui-monospace,monospace;
+    font-size:11px;
+    letter-spacing:.08em;
+    color:var(--muted);
+    text-transform:uppercase;
+  }
+  .meta b{color:var(--ink);font-weight:500}
+
+  /* —— sections —— */
+  section{margin-bottom:56px}
+  h2{
+    font-family:"IBM Plex Mono",ui-monospace,monospace;
+    font-size:11px;
+    letter-spacing:.18em;
+    text-transform:uppercase;
+    color:var(--muted);
+    margin-bottom:24px;
+    padding-bottom:10px;
+    border-bottom:1px solid var(--rule);
+  }
+
+  /* —— TL;DR —— */
+  .tldr{
+    background:var(--accent-soft);
+    border-left:3px solid var(--accent);
+    padding:24px 28px;
+    border-radius:2px;
+  }
+  .tldr p{
+    font-family:"Newsreader",ui-serif,Georgia,serif;
+    font-size:18px;
+    line-height:1.55;
+    color:var(--ink);
+  }
+  .tldr p + p{margin-top:14px}
+  .tldr strong{color:var(--accent);font-weight:500}
+
+  /* —— pain → status row —— */
+  .item{
+    display:grid;
+    grid-template-columns:1fr auto;
+    gap:24px;
+    padding:18px 0;
+    border-bottom:1px solid var(--rule);
+    align-items:start;
+  }
+  .item:last-child{border-bottom:none}
+  .item .lbl{
+    font-family:"IBM Plex Mono",ui-monospace,monospace;
+    font-size:10px;
+    letter-spacing:.16em;
+    color:var(--muted);
+    text-transform:uppercase;
+    margin-bottom:6px;
+  }
+  .item h3{
+    font-family:"Newsreader",ui-serif,Georgia,serif;
+    font-weight:500;
+    font-size:18px;
+    line-height:1.3;
+    color:var(--ink);
+    letter-spacing:-0.005em;
+    margin-bottom:6px;
+  }
+  .item p{
+    font-size:14px;
+    line-height:1.55;
+    color:var(--soft);
+    max-width:520px;
+  }
+  .stat{
+    display:inline-flex;
+    align-items:center;
+    gap:8px;
+    font-family:"IBM Plex Mono",ui-monospace,monospace;
+    font-size:10.5px;
+    letter-spacing:.14em;
+    text-transform:uppercase;
+    font-weight:500;
+    white-space:nowrap;
+    padding-top:4px;
+  }
+  .stat::before{
+    content:"";
+    width:7px;height:7px;border-radius:50%;
+  }
+  .stat.done{color:var(--done)} .stat.done::before{background:var(--done)}
+  .stat.partial{color:var(--partial)} .stat.partial::before{background:var(--partial)}
+  .stat.gap{color:var(--gap)} .stat.gap::before{background:var(--gap)}
+
+  /* —— issues —— */
+  .issue{
+    display:grid;
+    grid-template-columns:72px 1fr auto;
+    gap:20px;
+    padding:18px 0;
+    border-bottom:1px solid var(--rule);
+    align-items:baseline;
+  }
+  .issue:last-child{border-bottom:none}
+  .issue .num{
+    font-family:"IBM Plex Mono",ui-monospace,monospace;
+    font-size:13px;
+    font-weight:500;
+    color:var(--accent);
+    letter-spacing:.04em;
+  }
+  .issue .body h3{
+    font-family:"Newsreader",ui-serif,Georgia,serif;
+    font-weight:500;
+    font-size:17px;
+    line-height:1.3;
+    color:var(--ink);
+    margin-bottom:4px;
+    letter-spacing:-0.005em;
+  }
+  .issue .body p{
+    font-size:13.5px;
+    line-height:1.5;
+    color:var(--soft);
+  }
+  .pri{
+    font-family:"IBM Plex Mono",ui-monospace,monospace;
+    font-size:10px;
+    letter-spacing:.14em;
+    color:var(--muted);
+    text-transform:uppercase;
+    padding:3px 9px;
+    border:1px solid var(--rule);
+    border-radius:2px;
+    white-space:nowrap;
+  }
+  .pri.p0{color:var(--gap);border-color:var(--gap)}
+  .pri.p1{color:var(--partial);border-color:var(--partial)}
+  .pri.p2{color:var(--muted)}
+
+  a{color:inherit}
+  a.issue:hover{background:rgba(15,92,77,0.025)}
+
+  footer{
+    margin-top:48px;
+    padding-top:20px;
+    border-top:1px solid var(--rule);
+    font-family:"IBM Plex Mono",ui-monospace,monospace;
+    font-size:10.5px;
+    letter-spacing:.14em;
+    text-transform:uppercase;
+    color:var(--muted);
+    display:flex;
+    justify-content:space-between;
+    flex-wrap:wrap;
+    gap:14px;
+  }
+  footer a{color:var(--accent);text-decoration:none}
+
+  @media (max-width:640px){
+    .doc{padding:36px 20px 64px}
+    h1{font-size:32px}
+    .lede{font-size:17px}
+    .item{grid-template-columns:1fr}
+    .issue{grid-template-columns:1fr;gap:6px}
+    .issue .num{font-size:12px}
+  }
+</style>
+</head>
+<body>
+<div class="doc">
+
+  <header>
+    <div class="kicker">AASCU Discovery · Gap Analysis · Brief</div>
+    <h1>What the tool already does, what it's missing, what to build next.</h1>
+    <p class="lede">A two-page condensation of the AASCU intermediary discovery session and the eight issues filed against the codebenders-dashboard backlog.</p>
+    <div class="meta">
+      <span><b>2026·04·29</b></span>
+      <span>2 intermediaries</span>
+      <span>21 min source</span>
+      <span>8 issues filed</span>
+    </div>
+  </header>
+
+  <section>
+    <h2>The take</h2>
+    <div class="tldr">
+      <p>Intermediaries describe pain in three layers: <strong>PDP dashboard quality</strong> (charts, definitions, exports, accuracy), <strong>AI &amp; data governance</strong> (lineage, transparency, sensitive populations), and <strong>institutional process</strong> (knowledge silos, inconsistent submission rituals).</p>
+      <p>The tool already addresses meaningful parts of layer one and is in-flight on layer two via the SHAP narrator. The biggest unaddressed gaps are <strong>a definitions glossary, presentation-ready chart export, a data-lineage view, and AI transparency + sensitive-population safeguards</strong>.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>Pain × Coverage</h2>
+
+    <div class="item">
+      <div>
+        <div class="lbl">A · Data accuracy</div>
+        <h3>Numbers don't add up; PDP pulls from wrong dataset</h3>
+        <p>Validation report on upload addresses the institutional side; PDP-side accuracy is out of scope.</p>
+      </div>
+      <span class="stat partial">Partial</span>
+    </div>
+
+    <div class="item">
+      <div>
+        <div class="lbl">B · Definitions</div>
+        <h3>Metrics undefined in-context; mismatch with IPEDS / state</h3>
+        <p>Tooltip primitive exists. Centralized glossary and cross-walks not yet built.</p>
+      </div>
+      <span class="stat gap">Gap</span>
+    </div>
+
+    <div class="item">
+      <div>
+        <div class="lbl">C · Visualization</div>
+        <h3>Wrong chart types in PDP; ours are sane</h3>
+        <p>Recharts components, types chosen per metric. Done.</p>
+      </div>
+      <span class="stat done">Done</span>
+    </div>
+
+    <div class="item">
+      <div>
+        <div class="lbl">C · Export</div>
+        <h3>CSV from dashboard; no presentation-ready chart export</h3>
+        <p>CSV shipped (#15). PNG/PDF export with embedded definitions is the next step.</p>
+      </div>
+      <span class="stat partial">Partial</span>
+    </div>
+
+    <div class="item">
+      <div>
+        <div class="lbl">D · FERPA</div>
+        <h3>RBAC, audit log, FERPA-compliant identity resolution</h3>
+        <p>Issues #67, #75, #77, #78 closed. FERPA basics covered.</p>
+      </div>
+      <span class="stat done">Done</span>
+    </div>
+
+    <div class="item">
+      <div>
+        <div class="lbl">D · AI governance</div>
+        <h3>Transparency page, lineage view, sensitive-population safeguards</h3>
+        <p>Methodology page exists. SHAP narrator in flight. Lineage and transparency disclosures unbuilt.</p>
+      </div>
+      <span class="stat gap">Gap</span>
+    </div>
+
+    <div class="item">
+      <div>
+        <div class="lbl">E · Process</div>
+        <h3>Knowledge siloed; submission rituals vary per campus</h3>
+        <p>Self-service upload (#86) helps. Runbook generator would close the loop.</p>
+      </div>
+      <span class="stat partial">Partial</span>
+    </div>
+  </section>
+
+  <section>
+    <h2>Issues filed (#105 — #112)</h2>
+
+    <a class="issue" href="https://github.com/devcolor/codebenders-datathon/issues/105">
+      <div class="num">#105</div>
+      <div class="body">
+        <h3>Metric definitions glossary with IPEDS / state cross-walks</h3>
+        <p>Hover tooltips on every KPI · centralized <code>/glossary</code> page · markdown source-of-truth.</p>
+      </div>
+      <span class="pri p0">P0</span>
+    </a>
+
+    <a class="issue" href="https://github.com/devcolor/codebenders-datathon/issues/106">
+      <div class="num">#106</div>
+      <div class="body">
+        <h3>Presentation-ready chart export (PNG / PDF)</h3>
+        <p>Title, definition, source, date stamp baked in. Eliminates the manual Excel rebuild.</p>
+      </div>
+      <span class="pri p0">P0</span>
+    </a>
+
+    <a class="issue" href="https://github.com/devcolor/codebenders-datathon/issues/107">
+      <div class="num">#107</div>
+      <div class="body">
+        <h3>Data lineage view — "where did this number come from"</h3>
+        <p>Click any number → source rows, upload event, transformations, timestamps. Highest-leverage gap.</p>
+      </div>
+      <span class="pri p0">P0</span>
+    </a>
+
+    <a class="issue" href="https://github.com/devcolor/codebenders-datathon/issues/108">
+      <div class="num">#108</div>
+      <div class="body">
+        <h3>AI Transparency Page</h3>
+        <p>Per-model disclosure — features, training data, provider, data flow, retention. Reviewable independently.</p>
+      </div>
+      <span class="pri p1">P1</span>
+    </a>
+
+    <a class="issue" href="https://github.com/devcolor/codebenders-datathon/issues/109">
+      <div class="num">#109</div>
+      <div class="body">
+        <h3>Sensitive-population safeguards</h3>
+        <p>Per-institution feature exclusion · low-sample-size context warnings · audit log entries.</p>
+      </div>
+      <span class="pri p1">P1</span>
+    </a>
+
+    <a class="issue" href="https://github.com/devcolor/codebenders-datathon/issues/110">
+      <div class="num">#110</div>
+      <div class="body">
+        <h3>Upload validation report — diff vs. last upload</h3>
+        <p>Row-level errors, coercions, dedup decisions, dropped-campus flags. Readable by non-technical IR staff.</p>
+      </div>
+      <span class="pri p1">P1</span>
+    </a>
+
+    <a class="issue" href="https://github.com/devcolor/codebenders-datathon/issues/111">
+      <div class="num">#111</div>
+      <div class="body">
+        <h3>Submission runbook generator</h3>
+        <p>Capture what worked → printable runbook · replayable on new files · survives staff turnover.</p>
+      </div>
+      <span class="pri p2">P2</span>
+    </a>
+
+    <a class="issue" href="https://github.com/devcolor/codebenders-datathon/issues/112">
+      <div class="num">#112</div>
+      <div class="body">
+        <h3>Datathon institution grouping (SIS + goal)</h3>
+        <p>Operational artifact — cross-reference AASCU's SIS list with stated goals; output cohort matrix.</p>
+      </div>
+      <span class="pri p2">P2</span>
+    </a>
+  </section>
+
+  <footer>
+    <span>Brief · Bishop State CC · Codebenders Datathon</span>
+    <span>Full report → <a href="aascu_gap_analysis.html">aascu_gap_analysis.html</a></span>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/aascu_intermediary_feedback_summary.md
+++ b/docs/aascu_intermediary_feedback_summary.md
@@ -1,0 +1,146 @@
+# AASCU Intermediary Feedback — Summary & Tool Gap Analysis
+
+**Source:** AASCU Meeting Recording (~21 min) + typed notes from session
+**Participants:** Two AASCU Intermediaries (IFS) — one IR-focused (Andres), one data-engineering-focused (Dr. Prateek)
+**Date of analysis:** 2026-04-28
+
+> **Context — what is an Intermediary (IFS)?**
+> Intermediaries are organizations selected and funded by the Gates Foundation to support a network of institutions. They translate institutional needs into context, produce data-informed needs assessments, and connect institutions with support partners. They lean on each other as a peer cohort. Their feedback represents what *institutions they serve* are experiencing with PDP outputs.
+
+---
+
+## 1. Pain Points Raised
+
+### A. Data accuracy & trust in PDP outputs
+- Incorrect cohort sizes and missing institutions/campuses in dashboard dropdowns
+- Numbers reported by PDP dashboard appear inaccurate; intermediaries lack confidence in the data
+- PDP appears to pull from the wrong dataset intermittently
+- Andres: data is being **incorrectly processed at submission time** — institution data ends up with wrong values after going through PDP's pipeline
+- No cross-source verification — intermediaries and institutions have to take each other's word
+
+### B. Definitions & terminology
+- Terms like "completion rate at 3/4/5 years" and "first-to-second-year retention" are not clearly explained in-context
+- Definitions are buried in external documentation
+- PDP terminology differs from what institutions report for state compliance and IPEDS, creating cognitive friction
+
+### C. Visualization & data export
+- Wrong chart types (e.g., line chart used to compare independent cohorts — should be bar)
+- Charts are not presentation-ready; IR staff can't show them to supervisors as-is
+- **No data download from the dashboard.** Dr. Prateek had to manually copy individual numbers into Excel to build his own visualizations
+- The "analysis-ready file" is a paid add-on (~$20K), so most institutions don't have programmatic access to their own data
+
+### D. AI/governance constraints (for any new tool, including ours)
+- **FERPA compliance** is table-stakes
+- Beyond FERPA: concerns about "weaponizing data" via AI — broad analyses without institutional context can harm under-resourced campuses
+- Sensitive student populations (immigrant, undocumented, public-aid students) need special handling — clarity on which data points are used, and why
+- Need full **transparency** — homegrown vs. vendor model, what inputs are used, where data is stored
+- Need full **data lineage / governance** — "where did this number come from" must be answerable end-to-end
+- Vendors that promise "full automation" frequently underdeliver — so claims must be defensible
+
+### E. Institutional/process challenges (people, not tech)
+- Knowledge tends to live with **one person**; when they retire, no one else knows how the institution submits its data
+- Each campus has wildly different submission processes (e.g., one campus delists and re-uploads everything every cycle)
+- Institutions have very different sizes, types (university vs. junior college vs. multi-campus system), and goals — generic tools struggle to fit
+
+### F. Datathon coordination feedback
+- AASCU has a list of every institution's SIS — they can group institutions by **most common SIS** OR **most need**
+- Recommendation: group by **shared institutional goals** (e.g., "advising") in addition to shared SIS — that produced the strongest cross-talk in their program
+
+---
+
+## 2. What the Tool Already Addresses
+
+Mapping the pain points to what's already built or in progress in `codebenders-dashboard`:
+
+| Pain point | Already in tool | Evidence |
+|---|---|---|
+| **C. No data download** | ✅ CSV export wired into the dashboard | `components/export-button.tsx`, issue #15 (closed) |
+| **C. Wrong chart types** | ✅ Recharts-based, chart types chosen per metric | `retention-risk-chart.tsx`, `risk-alert-chart.tsx`, `readiness-assessment-chart.tsx` |
+| **B. Buried definitions** | 🟡 Partial — info popovers exist; not yet a full glossary | `components/info-popover.tsx` |
+| **D. AI transparency / methodology** | ✅ Methodology page documenting how predictions are made | `app/methodology/` |
+| **D. FERPA compliance** | ✅ RBAC, audit log, student-detail FERPA-compliant identity resolution | Issues #67, #75, #77, #78 (all closed) |
+| **D. Self-service & automation** | ✅ Self-service data upload (PDP, AR files, student/course data) | Issue #86 (closed), `components/upload/` |
+| **D. Explainability / "why this number"** | 🟡 In progress — SHAP narrator fine-tuning | Issues #97–103 (open epic), current branch `fine-tuning/97-shap-narrator-task-type` |
+| **A. Data validation on upload** | 🟡 Upload exists; validation surface area unknown | Issue #86 (need to verify what error reporting exists) |
+| **C. Filtering by cohort/term/demographic** | ✅ Built | Issue #66 (closed), #81 (closed) |
+| **C. Natural-language query against the data** | ✅ NLQ interface live | Issues #17, #61, #88, #90 (all closed); `lib/prompt-analyzer.ts` |
+| **E. Knowledge siloed in one person** | 🟡 Self-service upload reduces dependency, but no documented submission runbook in-app |  |
+
+**In short:** The tool already addresses a *substantial portion* of the pain — particularly the export/visualization gap (C), AI methodology transparency (D), and FERPA basics (D). The current SHAP narrator work (D) directly speaks to the "lack of context" risk Andres raised.
+
+---
+
+## 3. Gaps — Issues to Add
+
+These are pain points the tool does **not yet** address adequately. Recommended priorities are tentative — final priorities are yours to assign.
+
+### P0 — Differentiators that match the loudest complaints
+
+1. **Definitions glossary + inline tooltips for every metric**
+   *Pain points: B (definitions buried, terminology mismatch with IPEDS/state compliance)*
+   - Every metric/KPI shows a hover tooltip with: PDP definition, IPEDS-equivalent (if any), state-compliance term (if any)
+   - Centralized `/glossary` page indexed by metric
+   - Source-of-truth markdown so definitions are versioned with the code
+
+2. **Presentation-ready chart export (PNG/PDF), not just CSV**
+   *Pain point: C (charts can't be shown to supervisors)*
+   - "Export as PNG / PDF / PPTX-ready slide" on every chart
+   - Includes title, definitions, data source, and date stamp baked into the export
+   - Removes the manual "copy numbers to Excel and rebuild" workflow Dr. Prateek described
+
+3. **Data lineage / "where did this number come from" view**
+   *Pain points: A (trust gap), D (lineage requirement)*
+   - Click any number → see source rows, which upload it came from, transformations applied, and timestamp
+   - Critical for the AI-trust story: "we can prove every number"
+
+### P1 — AI governance hardening (table-stakes for institutional adoption)
+
+4. **AI Transparency Page**
+   *Pain point: D (which data points used, where stored, what model)*
+   - Lists every model (retention, GPA, etc.), the input features, the training data source, model lineage
+   - Shows whether the model is homegrown or third-party
+   - Lists the LLM provider for NLQ + SHAP narrator and where prompts/data flow
+
+5. **Sensitive-population safeguards**
+   *Pain point: D (immigrant/undocumented/public-aid students; weaponization risk)*
+   - Configurable "do not use" list of demographic features per institution
+   - When predictions are generated for flagged sub-populations, surface a context warning ("low sample size — interpret with care")
+   - Audit-log entry for any query/export that touches flagged populations
+
+6. **Upload validation report with human-readable error surface**
+   *Pain point: A (data-processing errors at submission), E (one person knows how)*
+   - After upload: show row-level errors, field coercions, deduplication decisions
+   - Must be readable by a non-technical IR staffer (so the tool survives the "person retires" scenario)
+   - "Diff vs. last upload" view so anomalies (e.g., dropped campuses) are caught immediately
+
+### P2 — Process / institutional fit
+
+7. **Submission runbook generator**
+   *Pain point: E (knowledge siloed in one person)*
+   - Tool records the exact upload steps + field mappings that "worked" for an institution
+   - Generates a printable/PDF runbook so a successor can replicate without tribal knowledge
+
+8. **Institution-grouping helper for shared-goal cohorts**
+   *Pain point: F (datathon coordination)*
+   - Operational, not a user-facing tool feature — but worth tracking as an internal issue:
+   - Pull the SIS-by-institution list from AASCU
+   - Cross-reference with stated institutional goals (e.g., "advising")
+   - Output a candidate grouping for the fall datathon
+
+### Out of scope (should NOT become tool issues)
+
+- **PDP-side cohort accuracy / dropdown completeness** — that's PDP's bug to fix; we shouldn't build around it
+- **The $20K analysis-ready file paywall** — pricing decision by PDP; not addressable in our tool
+- **Vendor over-promising on "full automation"** — competitive-positioning concern, not a feature
+
+---
+
+## 4. One-paragraph summary (for your notes doc)
+
+> Two AASCU Intermediaries described pain in three layers: (1) **PDP dashboard quality** — inaccurate cohort numbers, buried definitions, wrong chart types, no data export, forcing IR staff into manual Excel work; (2) **AI/governance requirements** — FERPA-plus expectations including data lineage, transparency on which data points are used and where stored, and explicit safeguards for sensitive student populations; and (3) **institutional process gaps** — submission knowledge typically lives with one person and varies wildly across campuses. Our tool already addresses a meaningful share of (1) — CSV export, sane chart types, NLQ, methodology page — and is in-flight on (2) via the SHAP-narrator work for explainability. The biggest unaddressed gaps are (a) a **definitions glossary with IPEDS/state-compliance cross-walks**, (b) **presentation-ready chart export** (PNG/PDF with definitions baked in), (c) a **data-lineage view** that proves where each number came from, and (d) **AI transparency + sensitive-population safeguards** as a precondition for institutional adoption. For datathon grouping, AASCU recommends pairing institutions by *shared SIS plus shared institutional goal* (e.g., advising) rather than SIS alone.
+
+---
+
+## 5. Suggested next step
+
+If you confirm the priorities above, I'll draft `gh issue create` commands for each P0/P1 — matching the labeling style of the existing repo (`area:*`, `type:feature`, `priority:*`) — and show them for review before creating anything.

--- a/docs/aascu_intermediary_feedback_summary_gdocs.md
+++ b/docs/aascu_intermediary_feedback_summary_gdocs.md
@@ -1,0 +1,156 @@
+# AASCU Intermediary Feedback — Summary & Tool Gap Analysis
+
+**Source:** AASCU Meeting Recording (~21 min) + typed notes from session
+
+**Participants:** Two AASCU Intermediaries (IFS) — one IR-focused (Andres), one data-engineering-focused (Dr. Prateek)
+
+**Date of analysis:** 2026-04-28
+
+> **Context — what is an Intermediary (IFS)?** Intermediaries are organizations selected and funded by the Gates Foundation to support a network of institutions. They translate institutional needs into context, produce data-informed needs assessments, and connect institutions with support partners. They lean on each other as a peer cohort. Their feedback represents what *institutions they serve* are experiencing with PDP outputs.
+
+---
+
+## 1. Pain Points Raised
+
+### A. Data accuracy & trust in PDP outputs
+
+- Incorrect cohort sizes and missing institutions/campuses in dashboard dropdowns
+- Numbers reported by PDP dashboard appear inaccurate; intermediaries lack confidence in the data
+- PDP appears to pull from the wrong dataset intermittently
+- Andres: data is being **incorrectly processed at submission time** — institution data ends up with wrong values after going through PDP's pipeline
+- No cross-source verification — intermediaries and institutions have to take each other's word
+
+### B. Definitions & terminology
+
+- Terms like "completion rate at 3/4/5 years" and "first-to-second-year retention" are not clearly explained in-context
+- Definitions are buried in external documentation
+- PDP terminology differs from what institutions report for state compliance and IPEDS, creating cognitive friction
+
+### C. Visualization & data export
+
+- Wrong chart types (e.g., line chart used to compare independent cohorts — should be bar)
+- Charts are not presentation-ready; IR staff can't show them to supervisors as-is
+- **No data download from the dashboard.** Dr. Prateek had to manually copy individual numbers into Excel to build his own visualizations
+- The "analysis-ready file" is a paid add-on (~$20K), so most institutions don't have programmatic access to their own data
+
+### D. AI/governance constraints (for any new tool, including ours)
+
+- **FERPA compliance** is table-stakes
+- Beyond FERPA: concerns about "weaponizing data" via AI — broad analyses without institutional context can harm under-resourced campuses
+- Sensitive student populations (immigrant, undocumented, public-aid students) need special handling — clarity on which data points are used, and why
+- Need full **transparency** — homegrown vs. vendor model, what inputs are used, where data is stored
+- Need full **data lineage / governance** — "where did this number come from" must be answerable end-to-end
+- Vendors that promise "full automation" frequently underdeliver — so claims must be defensible
+
+### E. Institutional/process challenges (people, not tech)
+
+- Knowledge tends to live with **one person**; when they retire, no one else knows how the institution submits its data
+- Each campus has wildly different submission processes (e.g., one campus delists and re-uploads everything every cycle)
+- Institutions have very different sizes, types (university vs. junior college vs. multi-campus system), and goals — generic tools struggle to fit
+
+### F. Datathon coordination feedback
+
+- AASCU has a list of every institution's SIS — they can group institutions by **most common SIS** OR **most need**
+- Recommendation: group by **shared institutional goals** (e.g., "advising") in addition to shared SIS — that produced the strongest cross-talk in their program
+
+---
+
+## 2. What the Tool Already Addresses
+
+Mapping the pain points to what's already built or in progress in `codebenders-dashboard`. Status legend: **Done** = shipped; **In progress** = active branch or open issue; **Partial** = some coverage, room to grow.
+
+**No data download (pain point C)** — *Done.* CSV export wired into the dashboard via `components/export-button.tsx` (issue #15).
+
+**Wrong chart types (pain point C)** — *Done.* Recharts-based components with chart types chosen per metric: `retention-risk-chart.tsx`, `risk-alert-chart.tsx`, `readiness-assessment-chart.tsx`.
+
+**Buried definitions (pain point B)** — *Partial.* `components/info-popover.tsx` exists for tooltips, but no centralized glossary or IPEDS/state cross-walks yet.
+
+**AI transparency / methodology (pain point D)** — *Done (foundation).* `app/methodology/` page documents how predictions are made. Will be deepened by the new AI Transparency Page issue.
+
+**FERPA compliance (pain point D)** — *Done.* RBAC (#75), audit log (#67), FERPA-compliant student-detail and SIS deep-link (#77, #78) — all closed.
+
+**Self-service & automation (pain point D)** — *Done.* Self-service data upload for PDP, AR files, student and course data shipped under issue #86, with UI in `components/upload/`.
+
+**Explainability / "why this number" (pain point D)** — *In progress.* SHAP narrator fine-tuning epic (issues #97–103, current branch `fine-tuning/97-shap-narrator-task-type`). Directly answers Andres's "broad analysis without context" concern.
+
+**Data validation on upload (pain point A)** — *Partial.* Upload exists (#86); the human-readable validation report layer is the new issue #110.
+
+**Filtering by cohort/term/demographic (pain point C)** — *Done.* Issues #66 and #81 (closed) shipped cohort/term/demographic/credential-type filters.
+
+**Natural-language query against the data (pain point C)** — *Done.* NLQ interface live via `lib/prompt-analyzer.ts`; issues #17, #61, #88, #90 (all closed).
+
+**Knowledge siloed in one person (pain point E)** — *Partial.* Self-service upload reduces single-person dependency, but no in-app submission runbook yet — addressed by new issue #111.
+
+**In short:** The tool already addresses a *substantial portion* of the pain — particularly the export/visualization gap (C), AI methodology transparency (D), and FERPA basics (D). The current SHAP narrator work (D) directly speaks to the "lack of context" risk Andres raised.
+
+---
+
+## 3. Gaps — Issues Filed
+
+These are pain points the tool does **not yet** address adequately. Issues have been created in GitHub.
+
+### P0 — Differentiators that match the loudest complaints
+
+**Issue #105 — Metric definitions glossary with IPEDS and state-compliance cross-walks**
+
+Pain points: B (definitions buried, terminology mismatch with IPEDS/state compliance).
+
+Every metric/KPI surfaces a hover tooltip with: PDP definition, IPEDS-equivalent (if any), state-compliance term (if any). Centralized `/glossary` page indexed by metric. Source-of-truth markdown so definitions are versioned with the code.
+
+**Issue #106 — Presentation-ready chart export (PNG/PDF) with definitions baked in**
+
+Pain point: C (charts can't be shown to supervisors).
+
+"Export as PNG / PDF" on every chart. Includes title, definitions, data source, and date stamp baked into the export. Removes the manual "copy numbers to Excel and rebuild" workflow.
+
+**Issue #107 — Data lineage view ("where did this number come from")**
+
+Pain points: A (trust gap), D (lineage requirement).
+
+Click any number → see source rows, which upload it came from, transformations applied, and timestamp. Critical for the AI-trust story: "we can prove every number." This is the highest-leverage gap from the session.
+
+### P1 — AI governance hardening (table-stakes for institutional adoption)
+
+**Issue #108 — AI Transparency Page**
+
+Pain point: D (which data points used, where stored, what model).
+
+Lists every model (retention, GPA, etc.), the input features, the training data source, and model lineage. Shows whether the model is homegrown or third-party. Lists the LLM provider for NLQ + SHAP narrator and where prompts/data flow.
+
+**Issue #109 — Sensitive-population safeguards**
+
+Pain point: D (immigrant/undocumented/public-aid students; weaponization risk).
+
+Configurable "do not use" list of demographic features per institution. When predictions are generated for flagged sub-populations, surface a context warning ("low sample size — interpret with care"). Audit-log entry for any query/export that touches flagged populations.
+
+**Issue #110 — Upload validation report with human-readable error surface**
+
+Pain points: A (data-processing errors at submission), E (one person knows how).
+
+After upload: row-level errors, field coercions, deduplication decisions. Must be readable by a non-technical IR staffer (so the tool survives the "person retires" scenario). "Diff vs. last upload" view so anomalies (e.g., dropped campuses) are caught immediately.
+
+### P2 — Process / institutional fit
+
+**Issue #111 — Submission runbook generator**
+
+Pain point: E (knowledge siloed in one person).
+
+Tool records the exact upload steps + field mappings that "worked" for an institution. Generates a printable/PDF runbook so a successor can replicate without tribal knowledge.
+
+**Issue #112 — Institution-grouping helper for shared-goal cohorts**
+
+Pain point: F (datathon coordination).
+
+Operational, not a user-facing tool feature. Pull the SIS-by-institution list from AASCU. Cross-reference with stated institutional goals (e.g., "advising"). Output a candidate grouping for the fall datathon.
+
+### Out of scope (intentionally not filed)
+
+- **PDP-side cohort accuracy / dropdown completeness** — that's PDP's bug to fix; we shouldn't build around it
+- **The $20K analysis-ready file paywall** — pricing decision by PDP; not addressable in our tool
+- **Vendor over-promising on "full automation"** — competitive-positioning concern, not a feature
+
+---
+
+## 4. One-paragraph summary
+
+Two AASCU Intermediaries described pain in three layers: (1) **PDP dashboard quality** — inaccurate cohort numbers, buried definitions, wrong chart types, no data export, forcing IR staff into manual Excel work; (2) **AI/governance requirements** — FERPA-plus expectations including data lineage, transparency on which data points are used and where stored, and explicit safeguards for sensitive student populations; and (3) **institutional process gaps** — submission knowledge typically lives with one person and varies wildly across campuses. Our tool already addresses a meaningful share of (1) — CSV export, sane chart types, NLQ, methodology page — and is in-flight on (2) via the SHAP-narrator work for explainability. The biggest unaddressed gaps are (a) a **definitions glossary with IPEDS/state-compliance cross-walks**, (b) **presentation-ready chart export** (PNG/PDF with definitions baked in), (c) a **data-lineage view** that proves where each number came from, and (d) **AI transparency + sensitive-population safeguards** as a precondition for institutional adoption. For datathon grouping, AASCU recommends pairing institutions by *shared SIS plus shared institutional goal* (e.g., advising) rather than SIS alone.

--- a/docs/aascu_intermediary_postmortem.md
+++ b/docs/aascu_intermediary_postmortem.md
@@ -1,0 +1,180 @@
+# AASCU Intermediary Discovery — Postmortem
+
+**Session:** Discovery conversation with two AASCU Intermediaries (IFS)
+
+**Participants:** Andres (IR-focused), Dr. Prateek (data-engineering-focused)
+
+**Source materials:** `AASCU Meeting Recording.m4a` (~21 min) + typed session notes
+
+---
+
+## Postmortem (4L)
+
+### Liked
+
+- Both intermediaries showed up candid and specific — concrete examples (line-graph misuse, the $20K AR-file paywall, the retiring-IR-lead anecdote) rather than abstract complaints.
+- Strong alignment between the two IFS on the *root* problem ("institutions can't trust or use PDP outputs"), even though they emphasized different layers — that means the pain is real, not idiosyncratic.
+- They volunteered AI-governance concerns unprompted, which validates that data lineage and transparency aren't over-engineering — they're table stakes.
+- Operational asset surfaced: AASCU has a SIS-by-institution list ready to share for datathon grouping.
+
+### Learned
+
+- The $20K analysis-ready file paywall is a real adoption barrier — most institutions are working off the dashboard alone.
+- Submission errors at the PDP processing layer (not at the institution) are corrupting downstream numbers — institutions get blamed for problems that aren't theirs.
+- Knowledge silos at institutions are *the* fragility point. One person retires and submission capability evaporates.
+- IR staff are already manually re-creating PDP charts in Excel before showing them to supervisors. The "rebuild it cleaner" workflow is a daily, repeated tax.
+- "Weaponizing data" is the IFS's mental model for AI risk — not technical risk, but institutional-harm risk to under-resourced campuses.
+- Datathon institutions should be grouped by **shared SIS + shared goal** (e.g., advising), not SIS alone. Last year's "wildly different incomes" cohort cost most of the day to find common ground.
+
+### Lacked
+
+- No live screen-share or walk-through of the PDP dashboard during the call — we're working from secondhand descriptions.
+- No representative from an actual institution (only intermediaries describing what institutions experience).
+- No quantification — we don't know *how many* institutions are affected by each pain point or how often.
+- No exposure to the AR file format itself, since neither IFS has paid for it. Our assumptions about its structure are still assumptions.
+
+### Longed For
+
+- A side-by-side "PDP says X, our tool says Y" comparison on the same dataset, to make the differentiation tangible.
+- A direct line to one or two institutions to validate the IFS-described pain points firsthand.
+- Definition cross-walks already published somewhere (state compliance ↔ IPEDS ↔ PDP) we could reuse rather than build.
+- Concrete examples of the "data weaponization" cases the IFS feared — to design safeguards against real scenarios, not hypotheticals.
+
+---
+
+## Immediate Takeaways
+
+### Broad strokes — what we heard
+
+Three layers of pain, two of them addressable by our tool:
+
+- **PDP dashboard quality** (charts, definitions, export, accuracy): partially addressable — we already cover much of this, with clear gaps to close.
+- **AI/governance expectations** (lineage, transparency, sensitive populations): fully addressable — and it's now table-stakes for institutional adoption.
+- **Institutional process gaps** (knowledge silos, submission inconsistency): addressable via tooling that captures and replays institutional knowledge.
+
+### Common challenges (both IFS independently raised)
+
+- Data accuracy / trust gap with PDP outputs
+- Buried, jargon-heavy definitions that don't match IPEDS or state compliance terms
+- Visualizations that aren't presentation-ready
+- AI governance: full transparency, full data lineage, sensitive-population care
+- Need for full automation — and skepticism that vendors deliver on it
+
+### Unique challenges
+
+- **Andres (IR-focused):** emphasized incorrect submission processing at PDP — the bug is in the pipeline, not the source data; and the knowledge-silo fragility (retiring IR lead).
+- **Dr. Prateek (data-engineering-focused):** emphasized hands-on friction — manually copying numbers into Excel, no download path, the cost of presentation rebuilds.
+
+### Clear problem space
+
+The tool is positioned to be **"PDP outputs you can trust, present, and govern"** — three things institutions can't get from PDP alone today. The differentiator is provable lineage + presentation-ready outputs + AI safeguards, layered on the predictions we already produce.
+
+---
+
+## Flags
+
+### Red Flags — risk / concerns
+
+- **AI weaponization risk is real to IFS, not theoretical.** Any misstep on sensitive populations (immigrant, undocumented, public-aid students) torpedoes institutional trust permanently.
+- **PDP-side data corruption is outside our control** but could be blamed on us if we don't surface it clearly. We need to make the source-of-truth boundary explicit.
+- **Vendors in this space have a credibility deficit** ("vendors promise full automation; that does not happen"). We will be measured against that history.
+- **FERPA-plus expectations.** FERPA alone isn't enough — institutions want assurances on AI use, storage, and lineage that go beyond statute.
+
+### Green Flags — areas of opportunity
+
+- **Data lineage view** is unmet by PDP and is the single highest-leverage differentiator (see issue #107). Directly answers the trust gap.
+- **Presentation-ready chart export** (issue #106) eliminates a daily manual workflow for IR staff — high frequency, high pain, low-medium build cost.
+- **SHAP narrator** (in-flight, issues #97-103) maps almost word-for-word to the IFS's "AI without context" concern. Strong narrative for the datathon demo.
+- **Self-service upload** (#86, shipped) already lowers the knowledge-silo barrier — one of the loudest pain points is partially solved before we walked in.
+- **AASCU has the SIS list ready** — we can produce the datathon grouping artifact (#112) on a fast turnaround.
+
+### Yellow Flags — potential challenges
+
+- **Definitions cross-walk** (issue #105) requires authoritative IPEDS / state-compliance source data we don't have yet. Could become a research drag if the cross-walks aren't already documented somewhere.
+- **Institutional fit varies wildly** — university vs. junior college vs. multi-campus systems have different use cases. A generic tool will fight the same "wildly different incomes" problem the last datathon hit.
+- **Scope creep risk on lineage view (#107).** Done well it's a differentiator; done shallowly it's a feature flag. Needs a clear scope cut for datathon.
+- **No first-party institution voice yet.** All feedback is via intermediaries. There may be sub-pain-points or different priorities at the institution level we haven't surfaced.
+
+### Prep — what needs to be true / what we need to find out
+
+- Confirm with AASCU whether IPEDS / state-compliance ↔ PDP cross-walks already exist anywhere we can reuse.
+- Get the SIS-by-institution list from AASCU and overlay institutional goals to draft datathon groupings (issue #112).
+- Identify 1-2 institutions willing to do a 30-min validation call before the datathon to confirm the IFS-described pain points firsthand.
+- Decide whether to scope a "lineage view MVP" (e.g., one metric only) for the datathon vs. building it post-event.
+- Get clarity on which AI provider and data-flow story we'll commit to publicly (input for #108 AI Transparency Page).
+- Verify the FERPA/RBAC implementation (#75) covers sensitive-population audit-log requirements (#109), or scope the gap.
+
+---
+
+## Post Work — per IFS
+
+### Andres (IR-focused intermediary)
+
+**Completed template (discovery meeting):**
+
+- Role: IR-focused IFS, working with multiple institutions on submission and dashboard interpretation
+- Primary pain: data accuracy at submission/processing layer + knowledge silos
+- Top quote: *"Maybe the dashboard will sometimes pull from the wrong set"* and *"a lot of the knowledge tends to live with one person"*
+- Asks of our tool: provable accuracy, transparency on data flow, FERPA-plus governance
+
+**Ideation session — finalized problem space (Andres):**
+
+- "PDP outputs you can prove and audit." Center the data-lineage view (#107) and AI Transparency Page (#108) for his use cases.
+- Adjacent: upload validation report (#110) addresses his "submission processing is corrupting data" concern by catching anomalies institutions can act on.
+
+**Immediate follow-up questions for Andres:**
+
+1. Can you share examples (sanitized) of the "wrong dataset" PDP pulls — so we can model what verification looks like?
+2. Of the institutions you support, which 1-2 would you prioritize for a 30-min validation call before the fall datathon?
+3. Has AASCU already documented IPEDS ↔ PDP definition cross-walks anywhere we can reuse?
+4. What's the typical IR team size at your institutions, and how does that change what "self-serve" means in practice?
+
+**Concerns / flags (Andres):**
+
+- Strong skepticism of vendor over-promising — we should under-promise and demo working features, not slideware.
+- The "person retired" example suggests our submission runbook generator (#111) lands on real, recurring pain.
+
+**Datathon ideas + skills needed (Andres):**
+
+- Data-engineering / pipeline-focused track: ingestion, validation, lineage tracking
+- Skills: SQL, data modeling, audit-log design, Python/pandas for pipeline work
+
+### Dr. Prateek (data-engineering-focused intermediary)
+
+**Completed template (discovery meeting):**
+
+- Role: data-engineering-focused IFS, hands-on with PDP outputs and visualization rebuilds
+- Primary pain: friction in extracting, presenting, and trusting data
+- Top quote: *"I just went by each data point and then I had to copy that number ... into the Excel spreadsheet"*
+- Asks of our tool: easy export, clean visuals, careful AI handling of sensitive populations
+
+**Ideation session — finalized problem space (Dr. Prateek):**
+
+- "PDP outputs you can present and reuse." Center the presentation-ready chart export (#106), definitions glossary (#105), and sensitive-population safeguards (#109) for his use cases.
+- Adjacent: data-lineage view (#107) supports his "is this number right?" reflex.
+
+**Immediate follow-up questions for Dr. Prateek:**
+
+1. Walk us through your last "rebuild it in Excel" cycle — what did you have to do, step by step? (To scope #106 well.)
+2. Which sensitive-population categories should we make first-class in our exclusion lists? (Input for #109.)
+3. What chart types do you wish PDP offered that it doesn't?
+4. When you talk to your supervisors, what one or two charts do they actually care about? (To prioritize export polish.)
+
+**Concerns / flags (Dr. Prateek):**
+
+- AI sensitivity around immigrant/undocumented/public-aid students is paramount. We must demo our safeguards, not just claim them.
+- "Data is very sensitive" — implies he'll scrutinize our data-flow disclosures hard. The AI Transparency Page (#108) needs to be airtight.
+
+**Datathon ideas + skills needed (Dr. Prateek):**
+
+- Front-end / visualization / UX track: chart export, glossary tooltips, presentation polish
+- Skills: React, Recharts/D3, design sensibility, technical writing for definitions content
+
+---
+
+## What's next (mechanical)
+
+- 8 GitHub issues filed (#105-#112, see `docs/aascu_intermediary_feedback_summary.md` section 3)
+- Validation calls to schedule with 1-2 institutions
+- IPEDS / state-compliance cross-walk research before #105 (glossary) starts
+- AASCU SIS list + goals overlay to drive #112 (datathon grouping)

--- a/docs/superpowers/specs/2026-04-02-fine-tuning-student-explainability-design.md
+++ b/docs/superpowers/specs/2026-04-02-fine-tuning-student-explainability-design.md
@@ -1,0 +1,305 @@
+# Design Spec: Fine-Tuning for Student Explainability
+
+**Date:** 2026-04-02
+**Epic label:** `fine-tuning: student-explainability`
+**Epic branch:** `fine-tuning/student-explainability`
+**Status:** Draft
+
+---
+
+## 1. Goal
+
+Fine-tune a small language model (Qwen 3.5) on Bishop State domain data to replace GPT-4o-mini for three inference tasks in the dashboard. The primary value is improved explainability: advisors get SHAP-grounded, institution-aware narratives instead of templated rule-engine output. Secondary benefits include FERPA compliance (all inference on-premises), offline deployment, and institutional scalability.
+
+### Tasks to Fine-Tune
+
+| Task | Input | Output | Priority |
+|------|-------|--------|----------|
+| **SHAP Narrator** | SHAP values + student profile + risk factors | Grounded advisor narrative + interventions | Highest (new) |
+| **Summarizer** | Query results + original question | Plain-English summary for advisors | Medium (exists) |
+| **Explainer** | Course pairing stats (DFWI, delivery, instructor) | Data-driven analysis + recommendation | Medium (exists) |
+
+### Out of Scope
+
+- Query Analyzer (NL → SQL) — high risk, deferred to future epic
+- Model serving infrastructure (RunPod, dedicated GPU hosting) — use local Ollama for now
+
+## 2. Prerequisites
+
+Before the epic branch is created:
+
+1. **Merge `feature/distillation-pipeline` → `main`** — brings in `training/` pipeline modules, `schools/bishop-state/config.yaml`, seed queries, `model-client.ts`
+2. **Merge `feature/shap-explainability` → `main`** — brings in per-student SHAP computation (Step 10b), SHAP-aware `enrich_with_llm()`, student API SHAP exposure, feasibility report
+
+## 3. Epic Structure
+
+### Branching
+
+- **Epic branch:** `fine-tuning/student-explainability` (from `main` after prereq merges)
+- **Feature branches:** `fine-tuning/issue-N-description` → PR into epic branch
+- **Final PR:** epic branch → `main`
+
+### Issue Breakdown
+
+```
+                    +---------------+
+                    | #1 Prereq:    |
+                    | Merge both    |
+                    | branches      |
+                    +-------+-------+
+                            |
+               +------------+------------+
+               v            v            v
+         +----------+ +----------+ +----------+
+         | #2 SHAP  | | #3 Colab | | #4 Distill|
+         | narrator | | notebook | | summarizer|
+         | task type| | (Unsloth)| | + explain |
+         +----+-----+ +----+-----+ +----+-----+
+              |             |            |
+              v             |            |
+         +----------+      |            |
+         | #5 Distill|     |            |
+         | SHAP      |     |            |
+         | narrator  |     |            |
+         +----+-----+      |            |
+              |             |            |
+              +-------------+------------+
+                            v
+                      +----------+
+                      | #6 Train |
+                      | 4B + 9B  |
+                      | evaluate |
+                      +----+-----+
+                           |
+                      +----+-----+
+                      v          v
+                +----------+ +----------+
+                | #7 Export | | #8 Update|
+                | + wire   | | docs &   |
+                | dashboard| | report   |
+                +----------+ +----------+
+```
+
+| # | Title | Description | Depends | Labels |
+|---|-------|------------|---------|--------|
+| 1 | Merge distillation-pipeline and shap-explainability to main | Merge both feature branches, resolve conflicts, verify CI | — | `type:chore` |
+| 2 | Add SHAP narrator task type to training pipeline | New prompt template, output schema, seed data generator, eval metrics | #1 | `type:feature`, `area:ai` |
+| 3 | Build Colab training notebook (Unsloth + LoRA) | Single "Run All" notebook, parameterized config, 3-phase training, GGUF export. Replace `training/finetune.py` (MLX) with Unsloth wrapper. | #1 | `type:feature`, `area:ai` |
+| 4 | Distill training pairs for summarizer and explainer | Run distillation for both existing tasks (~1,500 pairs each via Claude API). Prepare datasets. | #1 | `type:feature`, `area:ai` |
+| 5 | Distill training pairs for SHAP narrator | Generate ~1,500 SHAP narrator pairs from student data + SHAP values. Requires SHAP data in DB. | #2 | `type:feature`, `area:ai` |
+| 6 | Train and evaluate 4B + 9B models | Run Colab notebook for both model sizes. Evaluate via ship criteria. Compare metrics, pick winner. | #3, #4, #5 | `type:spike`, `area:ai` |
+| 7 | Export models and wire into dashboard | GGUF export, Ollama registration, wire `model-client.ts` into consumer routes, update `enrich_with_llm` model string. | #6 | `type:feature`, `area:ai`, `area:frontend` |
+| 8 | Update documentation and feasibility report | Update feasibility report with actual results, update README and CLAUDE.md. | #6 | `type:documentation` |
+
+### Parallelism
+
+Issues #2, #3, and #4 can proceed concurrently after #1. Issue #5 waits only on #2. Issue #6 is the convergence point. Issues #7 and #8 are parallel after #6.
+
+## 4. Colab Notebook Design
+
+### Principles
+
+- **Single "Run All" execution.** No babysitting. No manual cell-by-cell.
+- **Parameterized at the top.** One config cell is the only thing the user edits.
+- **Checkpoint and resume.** If Colab disconnects, set `SKIP_DOMAIN_ADAPTATION=True` to resume from Phase 2.
+- **Chat template alignment.** Uses `tokenizer.apply_chat_template()` throughout — never manual ChatML tokenization (D4BL's critical lesson).
+
+### Notebook Structure
+
+```
+Cell 1: Configuration (ONLY cell the user edits)
+-------------------------------------------------
+SCHOOL = "bishop-state"
+MODEL_SIZES = ["4b", "9b"]
+REPO_URL = "https://github.com/codebenders/datathon.git"
+REPO_BRANCH = "fine-tuning/student-explainability"
+HF_TOKEN = ""                        # or userdata.get('HF_TOKEN')
+PHASE_1_EPOCHS = 1
+PHASE_2_EPOCHS = 7
+SKIP_DOMAIN_ADAPTATION = False       # True to reuse cached Phase 1
+
+Cell 2+: Fully autonomous
+-------------------------------------------------
+- GPU detection + validation (assert A100/T4/L4)
+- pip install unsloth, trl, peft
+- Clone repo, load schools/{SCHOOL}/config.yaml
+- For each model size:
+  - Phase 1: Domain adaptation
+    - Load base Qwen model via Unsloth (4-bit NF4)
+    - Train on training_data/{school}/domain.jsonl
+    - LoRA rank 16, all modules, 1 epoch, lr 2e-4, effective batch 32
+    - Save merged checkpoint
+  - Phase 2: Task adapters (narrator, summarizer, explainer)
+    - Load Phase 1 checkpoint
+    - Train LoRA adapter per task
+    - Eval after each task, print ship-criteria table
+    - Narrator: LoRA r=16, attention+FFN, 7 epochs, lr 1e-4
+    - Summarizer: LoRA r=8, attention only, 7 epochs, lr 1e-4
+    - Explainer: LoRA r=16, attention+FFN, 4 epochs, lr 1e-4
+  - Phase 3: GGUF export
+    - Quantize each task adapter to q4_k_m
+    - Upload to Google Drive (or HF Hub if HF_TOKEN provided)
+- Print comparison table: 4B vs 9B metrics across all tasks
+- Recommend winner based on ship criteria
+```
+
+### Training Hyperparameters
+
+Based on D4BL's proven configurations:
+
+| Parameter | Phase 1 (Domain) | Phase 2 (Tasks) |
+|-----------|------------------|-----------------|
+| LoRA rank | 16 | 8-16 (task-dependent) |
+| LoRA alpha | 32 | 16-32 |
+| Learning rate | 2e-4 | 1e-4 |
+| Batch size (per device) | 8 | 4-8 |
+| Gradient accumulation | 4 | 2-4 |
+| Epochs | 1 | 4-7 |
+| Max sequence length | 4096 | 4096-8192 |
+| Optimizer | AdamW 8-bit | AdamW 8-bit |
+| Precision | bf16 (A100) | bf16 (A100) |
+
+### What the Notebook Does NOT Do
+
+- Does not run distillation (that's local via `python -m training.distill`)
+- Does not register Ollama models (local after downloading GGUFs)
+- Does not modify the repo (read-only clone for config + training data)
+
+## 5. SHAP Narrator Task Design
+
+### New Task Type: `narrator`
+
+This is the highest-value task — it transforms per-student SHAP attribution data into advisor-facing narratives that explain *why* a student is at risk and *what specifically to do about it*.
+
+### Input Format (at inference)
+
+```json
+{
+  "student_profile": {
+    "enrollment_intensity": "Part-Time",
+    "gpa_year1": 1.4,
+    "math_placement": "R",
+    "course_completion_rate": 0.55,
+    "gateway_math_completed": false,
+    "at_risk_alert": "HIGH",
+    "retention_probability": 0.28
+  },
+  "readiness_score": 0.38,
+  "readiness_level": "low",
+  "risk_factors": [
+    "Low first-year GPA (1.4 / 4.0)",
+    "Gateway math not completed in Year 1"
+  ],
+  "shap": {
+    "retention": {
+      "base_value": 0.52,
+      "top_positive": [
+        {"feature": "total_credits_attempted", "shap_value": 0.05, "value": 12.0}
+      ],
+      "top_negative": [
+        {"feature": "CompletedGatewayMathYear1", "shap_value": -0.18, "value": 0.0},
+        {"feature": "Enrollment_Intensity_First_Term", "shap_value": -0.12, "value": 1.0}
+      ]
+    },
+    "gateway_math": { ... },
+    "low_gpa": { ... }
+  }
+}
+```
+
+### Output Schema
+
+```json
+{
+  "narrative": "2-3 sentence explanation grounded in SHAP attribution",
+  "key_drivers": [
+    "Gateway math not completed (-0.18 on retention)",
+    "Part-time enrollment (-0.12 on retention)"
+  ],
+  "recommended_actions": [
+    "Priority enrollment in MAT 100 next term",
+    "Explore full-time enrollment options and financial aid",
+    "Connect with Math Bootcamp (2x pass rate for participants)"
+  ],
+  "data_limitations": [
+    "Retention model trained on 2019-2023 cohorts; 2024+ patterns may differ"
+  ]
+}
+```
+
+### Distillation Strategy
+
+1. Pull ~4K students from `student_level_with_predictions` joined with `llm_recommendations`
+2. For each medium/low readiness student (~2K): build input from `shap_explanations` + `input_features` columns
+3. Send to Claude (teacher model) with system prompt grounded in Bishop State context from `config.yaml`
+4. Validate output JSON schema, deduplicate (Jaccard 1.0), split 80/10/10
+5. Target: ~1,500 validated training pairs
+
+### Eval Metrics (Ship Criteria)
+
+| Metric | Threshold | Blocking? |
+|--------|-----------|-----------|
+| `json_valid_rate` | >= 95% | Yes |
+| `schema_valid_rate` | >= 90% | Yes |
+| `shap_grounding_rate` | >= 80% (narrative mentions >= 2 of top-3 SHAP features) | Yes |
+| `action_specificity` | LLM-judged: are actions Bishop State-specific? | No |
+
+## 6. Dashboard Integration
+
+### Model Client as Single Adapter
+
+`model-client.ts` becomes the sole inference routing layer. Existing routes (`explain-pairing/route.ts`, `query-summary/route.ts`) that currently instantiate their own OpenAI clients will be refactored to call `generateExplanation()` and `generateSummary()` from `model-client.ts`.
+
+### Ollama Model Naming
+
+```
+bishop-state-narrator:{size}     # SHAP narrator
+bishop-state-summarizer:{size}   # Query summary
+bishop-state-explainer:{size}    # Course pairing
+```
+
+Where `{size}` is `4b` or `9b` based on evaluation results.
+
+### SHAP Narrator Integration Point
+
+`generate_readiness_scores.py` already has `--enrich-with-llm` with the SHAP-aware prompt. The only change is the model string:
+
+```bash
+# Before (OpenAI)
+python ai_model/generate_readiness_scores.py --enrich-with-llm --llm-model gpt-4o-mini
+
+# After (fine-tuned)
+python ai_model/generate_readiness_scores.py --enrich-with-llm --llm-model ollama/bishop-state-narrator:4b
+```
+
+### Environment Variables
+
+```env
+MODEL_BACKEND=ollama              # or "openai" (fallback)
+OLLAMA_BASE_URL=http://localhost:11434
+MODEL_SIZE=4b                     # set after evaluation picks winner
+SCHOOL_CODE=bishop-state
+```
+
+### Fallback Behavior
+
+The operator sets `MODEL_BACKEND` to either `ollama` or `openai`. There is no automatic failover — if Ollama is down and `MODEL_BACKEND=ollama`, the route returns an error. This is intentional: silent fallback to OpenAI would send student data to an external service without the operator's knowledge, violating the FERPA benefit.
+
+## 7. Cost Estimate
+
+| Item | Cost |
+|------|------|
+| Claude API distillation (~4,500 pairs across 3 tasks) | $5-10 |
+| Colab A100 compute (~4 hours for 2 model sizes) | $8-16 |
+| **Total per training run** | **$13-26** |
+| Iteration runs (subsequent) | $8-16 each |
+
+## 8. Success Criteria
+
+The epic is complete when:
+
+1. All three tasks pass ship criteria on the winning model size
+2. `MODEL_BACKEND=ollama` serves all three tasks in the dashboard without OpenAI
+3. SHAP narrator produces grounded narratives that cite specific feature attributions
+4. Feasibility report is updated with actual metrics and model selection rationale
+5. Colab notebook is documented and reproducible (clone + Run All)


### PR DESCRIPTION
## Summary

Adds the deliverable from a 21-minute discovery session with two AASCU Intermediaries (one IR-focused, one data-engineering-focused) describing how the PDP dashboard fails the institutions they serve. Ships both as **research artifacts** under `docs/` and as **auth-protected dashboard pages** under `/discovery/aascu`.

- New routes: `/discovery/aascu` (brief, single-column memo) and `/discovery/aascu/full` (long-form editorial)
- Auth gating via `ROUTE_PERMISSIONS` — restricted to `admin`, `ir`, `leadership`
- Discovery nav link added to `NavHeader` (visible to gated roles)
- Pages use `next/font/google` (Fraunces, Newsreader, IBM Plex Sans/Mono, JetBrains Mono) + scoped CSS Modules — design lives alongside Tailwind/shadcn without leaking
- 8 follow-up issues filed from this session: #105 — #112

## What's in `docs/`

| File | Purpose |
|---|---|
| `aascu_intermediary_feedback_summary.md` | Full report — 11-row pain-coverage matrix, P0/P1/P2 issue scoping |
| `aascu_intermediary_postmortem.md` | 4L (Liked / Learned / Lacked / Longed For) retrospective + per-IFS post-work |
| `aascu_gap_analysis.html` | Standalone editorial HTML for sharing without dashboard auth |
| `aascu_gap_analysis_simple.html` | Standalone brief HTML (companion to the above) |
| `aascu_intermediary_feedback_summary_gdocs.md` | Google-Docs-paste-friendly variant (tables flattened to definition lists) |

The standalone HTML files duplicate the dashboard pages on purpose — they're for external sharing (e.g., to AASCU stakeholders without dashboard accounts). The dashboard versions are the canonical, auth-protected source.

## Verification

- [x] `tsc --noEmit` clean for new files (4 pre-existing errors in unrelated files, not introduced here)
- [x] `npm run build` succeeds — both new routes appear in the route manifest
- [x] Auth gating confirmed via curl: unauthenticated requests to both routes return `307` → `/login`
- [ ] **Visual verification needed by reviewer**: log in as admin/ir/leadership, navigate to Discovery, confirm both pages render correctly and the NavHeader integrates without overlap

## Test plan

- [ ] Log in as `admin` → click "Discovery" in nav → brief loads with cream/forest aesthetic
- [ ] Click "aascu / full" footer link → editorial loads with cream/sienna aesthetic + animated hero
- [ ] Issue cards link to GitHub issues #105–#112 in new tab
- [ ] Log in as `advisor` or `faculty` → "Discovery" link is hidden, direct URL redirects to `/`
- [ ] Sign out, hit `/discovery/aascu` directly → redirected to `/login`
- [ ] Mobile (≤640px brief, ≤920px full) → grids collapse to single-column

## Notes

- Branch is off `main` directly (not the SHAP fine-tuning epic) — this work is independent.
- No new dependencies added; uses existing `next/font/google` pipeline already wired in root layout.
- CSS Modules introduced for the first time in this codebase, but they coexist cleanly with Tailwind (scoped class names, no globals affected).