### PR TITLE
feat: AI transparency page — model + LLM + data-API inventory (#108)

### DIFF
--- a/codebenders-dashboard/app/ai-transparency/page.tsx
+++ b/codebenders-dashboard/app/ai-transparency/page.tsx
@@ -1,0 +1,244 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowLeft, Bot, Cloud, Database, ServerCog, Sparkles } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { AI_SURFACES, type AISurface } from "@/content/ai-transparency"
+
+export const metadata: Metadata = {
+  title: "AI Transparency — Bishop State Student Success Dashboard",
+  description:
+    "What AI runs in this dashboard, where it runs, what data flows where, and what is retained.",
+}
+
+const CATEGORY_META: Record<
+  AISurface["category"],
+  { label: string; icon: typeof Bot; tint: string }
+> = {
+  ml_model: { label: "ML model", icon: ServerCog, tint: "text-emerald-600" },
+  natural_language: { label: "Natural language", icon: Sparkles, tint: "text-violet-600" },
+  explainability: { label: "Explainability", icon: Bot, tint: "text-sky-600" },
+  data_api: { label: "Data API", icon: Database, tint: "text-amber-600" },
+}
+
+function StatusBadge({ status }: { status: AISurface["status"] }) {
+  if (status === "deployed") {
+    return (
+      <Badge variant="outline" className="border-emerald-300 text-emerald-700 bg-emerald-50">
+        Deployed
+      </Badge>
+    )
+  }
+  return (
+    <Badge variant="outline" className="border-amber-300 text-amber-700 bg-amber-50">
+      In development
+    </Badge>
+  )
+}
+
+function ProvenanceBadge({ surface }: { surface: AISurface }) {
+  if (surface.homegrown) {
+    return (
+      <Badge variant="outline" className="border-slate-300 text-slate-700 bg-slate-50">
+        <ServerCog className="h-3 w-3 mr-1" />
+        Homegrown
+      </Badge>
+    )
+  }
+  return (
+    <Badge variant="outline" className="border-orange-300 text-orange-700 bg-orange-50">
+      <Cloud className="h-3 w-3 mr-1" />
+      Third-party: {surface.provider}
+    </Badge>
+  )
+}
+
+function SurfaceCard({ surface }: { surface: AISurface }) {
+  const cat = CATEGORY_META[surface.category]
+  const Icon = cat.icon
+  return (
+    <Card id={surface.id}>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3 flex-wrap">
+          <div className="flex items-center gap-2">
+            <Icon className={`h-5 w-5 ${cat.tint}`} />
+            <CardTitle className="text-lg">{surface.name}</CardTitle>
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <StatusBadge status={surface.status} />
+            <ProvenanceBadge surface={surface} />
+          </div>
+        </div>
+        <CardDescription>
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">{cat.label}</span>
+          <span className="mx-2 text-muted-foreground">•</span>
+          <span className="text-xs">Version: {surface.version}</span>
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <Field label="Algorithm" value={surface.algorithm} />
+        <Field
+          label="Inputs"
+          value={
+            <ul className="list-disc list-inside space-y-0.5 text-muted-foreground">
+              {surface.inputs.map((i) => (
+                <li key={i}>{i}</li>
+              ))}
+            </ul>
+          }
+        />
+        {surface.trainingData && (
+          <Field
+            label="Training data"
+            value={
+              <span className="text-muted-foreground">
+                {surface.trainingData.source}
+                <br />
+                <span className="text-xs">
+                  Cohort: {surface.trainingData.cohort}
+                  {surface.trainingData.rowCount ? ` • ~${surface.trainingData.rowCount}` : ""}
+                </span>
+              </span>
+            }
+          />
+        )}
+        <Field label="Where it runs" value={surface.runsOn} />
+        <Field label="Data flow on invocation" value={surface.dataFlow} />
+        <Field label="Retention policy" value={surface.retentionPolicy} />
+        {surface.notes && (
+          <div className="border-l-2 border-amber-300 bg-amber-50/40 px-3 py-2 rounded-r text-muted-foreground">
+            <span className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+              Note
+            </span>
+            <p className="mt-1">{surface.notes}</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-xs font-semibold uppercase tracking-wide text-foreground/70 mb-1">
+        {label}
+      </div>
+      <div className="text-muted-foreground whitespace-pre-line">{value}</div>
+    </div>
+  )
+}
+
+export default function AITransparencyPage() {
+  const grouped: Record<string, AISurface[]> = {
+    ml_model: [],
+    natural_language: [],
+    explainability: [],
+    data_api: [],
+  }
+  for (const s of AI_SURFACES) grouped[s.category].push(s)
+
+  const sectionOrder: AISurface["category"][] = [
+    "ml_model",
+    "natural_language",
+    "data_api",
+    "explainability",
+  ]
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto p-6 space-y-8 max-w-4xl">
+        {/* Header */}
+        <div className="border-b border-border pb-6">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-4"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Dashboard
+          </Link>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">AI Transparency</h1>
+          <p className="text-muted-foreground mt-2">
+            What AI is running in this dashboard, where it runs, what data flows where, and what is
+            retained. Maintained as a living inventory — entries describe what is{" "}
+            <em>deployed today</em>, with planned features clearly flagged.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2 text-xs">
+            <Link
+              href="/methodology"
+              className="text-blue-600 hover:underline"
+            >
+              See also: Readiness Methodology →
+            </Link>
+          </div>
+        </div>
+
+        {/* How to read this page */}
+        <Card className="bg-muted/30">
+          <CardHeader>
+            <CardTitle className="text-base">How to read this page</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground space-y-2">
+            <p>
+              Every AI or AI-adjacent surface in the dashboard is listed below with: the algorithm,
+              the inputs, the training data (if any), where the inference runs, what data flows on
+              invocation, and the retention policy.
+            </p>
+            <p>
+              <strong className="text-foreground">Homegrown</strong> surfaces run on
+              institution-controlled infrastructure with no third-party data flow.{" "}
+              <strong className="text-foreground">Third-party</strong> surfaces transmit data to an
+              external provider — those entries spell out exactly what is sent, what is excluded,
+              and what the provider retains.
+            </p>
+            <p>
+              <strong className="text-foreground">In development</strong> entries are not running in
+              production today — they are listed for full lifecycle transparency so institutions can
+              evaluate what is coming alongside what exists.
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* Surfaces grouped by category */}
+        {sectionOrder.map((category) => {
+          const items = grouped[category]
+          if (items.length === 0) return null
+          const cat = CATEGORY_META[category]
+          const Icon = cat.icon
+          return (
+            <section key={category} className="space-y-4">
+              <div className="flex items-center gap-2">
+                <Icon className={`h-5 w-5 ${cat.tint}`} />
+                <h2 className="text-xl font-semibold">{cat.label}s</h2>
+                <span className="text-xs text-muted-foreground">({items.length})</span>
+              </div>
+              <div className="grid gap-4">
+                {items.map((s) => (
+                  <SurfaceCard key={s.id} surface={s} />
+                ))}
+              </div>
+            </section>
+          )
+        })}
+
+        {/* Footer / contact */}
+        <section className="border-t border-border pt-6 text-sm text-muted-foreground space-y-2">
+          <p>
+            This page is maintained at{" "}
+            <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+              codebenders-dashboard/content/ai-transparency.ts
+            </code>
+            . Each entry corresponds to code in the repository — see{" "}
+            <code className="text-xs bg-muted px-1.5 py-0.5 rounded">ai_model/</code> for the ML
+            pipeline and <code className="text-xs bg-muted px-1.5 py-0.5 rounded">app/api/</code>{" "}
+            for the LLM-backed routes.
+          </p>
+          <p>
+            Questions or audit requests should be directed to your institutional point-of-contact
+            for this deployment.
+          </p>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/codebenders-dashboard/app/ai-transparency/page.tsx
+++ b/codebenders-dashboard/app/ai-transparency/page.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from "next"
+import type { ReactNode } from "react"
 import Link from "next/link"
 import { ArrowLeft, Bot, Cloud, Database, ServerCog, Sparkles } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { AI_SURFACES, type AISurface } from "@/content/ai-transparency"
+import {
+  AI_SURFACE_CATEGORY_ORDER,
+  AI_SURFACES,
+  groupAISurfacesByCategory,
+  type AISurface,
+} from "@/content/ai-transparency"
 
 export const metadata: Metadata = {
   title: "AI Transparency — Bishop State Student Success Dashboard",
@@ -13,12 +19,32 @@ export const metadata: Metadata = {
 
 const CATEGORY_META: Record<
   AISurface["category"],
-  { label: string; icon: typeof Bot; tint: string }
+  { label: string; sectionTitle: string; icon: typeof Bot; tint: string }
 > = {
-  ml_model: { label: "ML model", icon: ServerCog, tint: "text-emerald-600" },
-  natural_language: { label: "Natural language", icon: Sparkles, tint: "text-violet-600" },
-  explainability: { label: "Explainability", icon: Bot, tint: "text-sky-600" },
-  data_api: { label: "Data API", icon: Database, tint: "text-amber-600" },
+  ml_model: {
+    label: "ML model",
+    sectionTitle: "ML models",
+    icon: ServerCog,
+    tint: "text-emerald-600",
+  },
+  natural_language: {
+    label: "Natural language",
+    sectionTitle: "Natural languages",
+    icon: Sparkles,
+    tint: "text-violet-600",
+  },
+  explainability: {
+    label: "Explainability",
+    sectionTitle: "Explainability",
+    icon: Bot,
+    tint: "text-sky-600",
+  },
+  data_api: {
+    label: "Data API",
+    sectionTitle: "Data APIs",
+    icon: Database,
+    tint: "text-amber-600",
+  },
 }
 
 function StatusBadge({ status }: { status: AISurface["status"] }) {
@@ -81,8 +107,8 @@ function SurfaceCard({ surface }: { surface: AISurface }) {
           label="Inputs"
           value={
             <ul className="list-disc list-inside space-y-0.5 text-muted-foreground">
-              {surface.inputs.map((i) => (
-                <li key={i}>{i}</li>
+              {surface.inputs.map((line, index) => (
+                <li key={`${surface.id}-in-${index}`}>{line}</li>
               ))}
             </ul>
           }
@@ -96,7 +122,7 @@ function SurfaceCard({ surface }: { surface: AISurface }) {
                 <br />
                 <span className="text-xs">
                   Cohort: {surface.trainingData.cohort}
-                  {surface.trainingData.rowCount ? ` • ~${surface.trainingData.rowCount}` : ""}
+                  {surface.trainingData.rowCount ? ` • ${surface.trainingData.rowCount}` : ""}
                 </span>
               </span>
             }
@@ -118,7 +144,7 @@ function SurfaceCard({ surface }: { surface: AISurface }) {
   )
 }
 
-function Field({ label, value }: { label: string; value: React.ReactNode }) {
+function Field({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div>
       <div className="text-xs font-semibold uppercase tracking-wide text-foreground/70 mb-1">
@@ -130,20 +156,7 @@ function Field({ label, value }: { label: string; value: React.ReactNode }) {
 }
 
 export default function AITransparencyPage() {
-  const grouped: Record<string, AISurface[]> = {
-    ml_model: [],
-    natural_language: [],
-    explainability: [],
-    data_api: [],
-  }
-  for (const s of AI_SURFACES) grouped[s.category].push(s)
-
-  const sectionOrder: AISurface["category"][] = [
-    "ml_model",
-    "natural_language",
-    "data_api",
-    "explainability",
-  ]
+  const grouped = groupAISurfacesByCategory(AI_SURFACES)
 
   return (
     <div className="min-h-screen bg-background">
@@ -200,7 +213,7 @@ export default function AITransparencyPage() {
         </Card>
 
         {/* Surfaces grouped by category */}
-        {sectionOrder.map((category) => {
+        {AI_SURFACE_CATEGORY_ORDER.map((category) => {
           const items = grouped[category]
           if (items.length === 0) return null
           const cat = CATEGORY_META[category]
@@ -209,7 +222,7 @@ export default function AITransparencyPage() {
             <section key={category} className="space-y-4">
               <div className="flex items-center gap-2">
                 <Icon className={`h-5 w-5 ${cat.tint}`} />
-                <h2 className="text-xl font-semibold">{cat.label}s</h2>
+                <h2 className="text-xl font-semibold">{cat.sectionTitle}</h2>
                 <span className="text-xs text-muted-foreground">({items.length})</span>
               </div>
               <div className="grid gap-4">

--- a/codebenders-dashboard/app/methodology/page.tsx
+++ b/codebenders-dashboard/app/methodology/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { AI_TRANSPARENCY_HREF } from "@/content/ai-transparency"
 import Link from "next/link"
 import { ArrowLeft, BookOpen, FlaskConical, GraduationCap, ShieldCheck } from "lucide-react"
 
@@ -395,7 +396,7 @@ export default function MethodologyPage() {
           <p className="text-sm text-muted-foreground">
             For an inventory of every AI surface in this dashboard — what it is, where it runs,
             what data flows where, and what is retained — see the{" "}
-            <Link href="/ai-transparency" className="text-blue-600 hover:underline">
+            <Link href={AI_TRANSPARENCY_HREF} className="text-blue-600 hover:underline">
               AI Transparency page
             </Link>
             .

--- a/codebenders-dashboard/app/methodology/page.tsx
+++ b/codebenders-dashboard/app/methodology/page.tsx
@@ -389,6 +389,19 @@ export default function MethodologyPage() {
           </Card>
         </section>
 
+        {/* Cross-link to AI Transparency */}
+        <section className="space-y-2 border-t border-border pt-6">
+          <h2 className="text-lg font-semibold">See also</h2>
+          <p className="text-sm text-muted-foreground">
+            For an inventory of every AI surface in this dashboard — what it is, where it runs,
+            what data flows where, and what is retained — see the{" "}
+            <Link href="/ai-transparency" className="text-blue-600 hover:underline">
+              AI Transparency page
+            </Link>
+            .
+          </p>
+        </section>
+
         {/* Citations */}
         <section className="space-y-4 border-t border-border pt-6">
           <h2 className="text-lg font-semibold">References</h2>

--- a/codebenders-dashboard/components/nav-header.tsx
+++ b/codebenders-dashboard/components/nav-header.tsx
@@ -18,6 +18,7 @@ const NAV_LINKS: Array<{ href: string; label: string; roles?: Role[] }> = [
   { href: "/students",  label: "Students"  },
   { href: "/query",     label: "Query"     },
   { href: "/discovery/aascu", label: "Discovery", roles: ["admin", "ir", "leadership"] },
+  { href: "/ai-transparency", label: "AI Transparency" },
   { href: "/admin/upload", label: "Admin", roles: ["admin", "ir"] },
 ]
 

--- a/codebenders-dashboard/components/nav-header.tsx
+++ b/codebenders-dashboard/components/nav-header.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation"
 import { GraduationCap, LogOut } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { signOut } from "@/app/actions/auth"
+import { AI_TRANSPARENCY_HREF } from "@/content/ai-transparency"
 import { ROLE_COLORS, ROLE_LABELS, type Role } from "@/lib/roles"
 
 interface NavHeaderProps {
@@ -13,12 +14,12 @@ interface NavHeaderProps {
 }
 
 const NAV_LINKS: Array<{ href: string; label: string; roles?: Role[] }> = [
-  { href: "/",          label: "Dashboard" },
-  { href: "/courses",   label: "Courses"   },
-  { href: "/students",  label: "Students"  },
-  { href: "/query",     label: "Query"     },
+  { href: "/", label: "Dashboard" },
+  { href: "/courses", label: "Courses" },
+  { href: "/students", label: "Students" },
+  { href: "/query", label: "Query" },
   { href: "/discovery/aascu", label: "Discovery", roles: ["admin", "ir", "leadership"] },
-  { href: "/ai-transparency", label: "AI Transparency" },
+  { href: AI_TRANSPARENCY_HREF, label: "AI Transparency" },
   { href: "/admin/upload", label: "Admin", roles: ["admin", "ir"] },
 ]
 

--- a/codebenders-dashboard/content/ai-transparency.ts
+++ b/codebenders-dashboard/content/ai-transparency.ts
@@ -1,0 +1,349 @@
+/**
+ * AI Transparency Page Content
+ *
+ * Single source of truth for the /ai-transparency page. One entry per AI or
+ * AI-adjacent surface actually deployed in the dashboard.
+ *
+ * Editing rule: this file describes what is RUNNING TODAY. Aspirational or
+ * planned features go in `status: "in_development"` with a clear note about
+ * what is and isn't live. If you find yourself writing "the system will..."
+ * about a deployed feature, stop — say what it does NOW.
+ */
+
+export type AISurfaceStatus = "deployed" | "in_development"
+
+export interface AISurface {
+  id: string
+  name: string
+  status: AISurfaceStatus
+  category: "ml_model" | "natural_language" | "explainability" | "data_api"
+  homegrown: boolean
+  provider: string | null
+  algorithm: string
+  version: string
+  inputs: string[]
+  trainingData: {
+    source: string
+    cohort: string
+    rowCount?: string
+  } | null
+  runsOn: string
+  dataFlow: string
+  retentionPolicy: string
+  notes?: string
+}
+
+export const AI_SURFACES: AISurface[] = [
+  // ─────────────────────────── ML models (6, all homegrown) ───────────────────────────
+  {
+    id: "retention-prediction",
+    name: "Retention Prediction",
+    status: "deployed",
+    category: "ml_model",
+    homegrown: true,
+    provider: null,
+    algorithm:
+      "XGBoost classifier (selected from XGBoost / Logistic Regression / Random Forest comparison in `ai_model/complete_ml_pipeline.py`)",
+    version: "1.0",
+    inputs: [
+      "Cohort year and term",
+      "Enrollment intensity (full-time / part-time)",
+      "Pell eligibility",
+      "First-generation status",
+      "Year-1 GPA band",
+      "Year-1 credits earned",
+      "Program of study",
+    ],
+    trainingData: {
+      source: "Bishop State Community College historical PDP submissions",
+      cohort: "Cohorts 2018-2022",
+      rowCount: "~4,000 students",
+    },
+    runsOn: "On-premise / institution-controlled infrastructure. No third-party inference API.",
+    dataFlow:
+      "Features are read from the institution's Postgres database, fed to the local XGBoost model, and the resulting probability is written back to `student_predictions` in the same database. No data leaves institutional infrastructure during inference.",
+    retentionPolicy:
+      "Predictions stored in `student_predictions`. The model file is checked into the institutional deployment.",
+  },
+  {
+    id: "time-to-credential",
+    name: "Time-to-Credential Prediction",
+    status: "deployed",
+    category: "ml_model",
+    homegrown: true,
+    provider: null,
+    algorithm: "Random Forest regressor",
+    version: "1.0",
+    inputs: [
+      "Cohort year and term",
+      "Enrollment intensity",
+      "Year-1 GPA band",
+      "Year-1 credits earned",
+      "Program of study",
+      "Gateway math/English completion flags",
+    ],
+    trainingData: {
+      source: "Bishop State Community College historical PDP submissions",
+      cohort: "Cohorts 2018-2022 with observed credential completion",
+      rowCount: "~4,000 students",
+    },
+    runsOn: "On-premise / institution-controlled infrastructure.",
+    dataFlow:
+      "Local-only inference. Features in from local Postgres, prediction out to local Postgres. No outbound network calls during inference.",
+    retentionPolicy: "Predictions stored in `student_predictions`. Model file in institutional deployment.",
+  },
+  {
+    id: "credential-type",
+    name: "Credential Type Prediction",
+    status: "deployed",
+    category: "ml_model",
+    homegrown: true,
+    provider: null,
+    algorithm:
+      "Random Forest multi-class classifier (4 classes: No Credential, Certificate, Associate, Bachelor)",
+    version: "1.0",
+    inputs: [
+      "Cohort year and term",
+      "Enrollment intensity",
+      "Year-1 GPA band",
+      "Year-1 credits earned",
+      "Program of study",
+      "Gateway math/English completion flags",
+    ],
+    trainingData: {
+      source: "Bishop State Community College historical PDP submissions",
+      cohort: "Cohorts 2018-2022 with observed credential outcomes",
+      rowCount: "~4,000 students",
+    },
+    runsOn: "On-premise / institution-controlled infrastructure.",
+    dataFlow: "Local-only inference; per-class probabilities written to `student_predictions`.",
+    retentionPolicy: "Predictions stored in `student_predictions`. No third-party data flow.",
+  },
+  {
+    id: "gateway-math",
+    name: "Gateway Math Success Prediction",
+    status: "deployed",
+    category: "ml_model",
+    homegrown: true,
+    provider: null,
+    algorithm: "XGBoost classifier",
+    version: "1.0",
+    inputs: [
+      "Cohort year and term",
+      "Enrollment intensity",
+      "Year-1 GPA band",
+      "Math placement / readiness indicators",
+      "Program of study",
+    ],
+    trainingData: {
+      source: "Bishop State Community College historical PDP submissions",
+      cohort: "Cohorts 2018-2022 with observed gateway math completion",
+      rowCount: "~4,000 students",
+    },
+    runsOn: "On-premise / institution-controlled infrastructure.",
+    dataFlow: "Local-only inference; probability written to `student_predictions`.",
+    retentionPolicy: "Predictions stored in `student_predictions`. No third-party data flow.",
+  },
+  {
+    id: "gateway-english",
+    name: "Gateway English Success Prediction",
+    status: "deployed",
+    category: "ml_model",
+    homegrown: true,
+    provider: null,
+    algorithm: "XGBoost classifier",
+    version: "1.0",
+    inputs: [
+      "Cohort year and term",
+      "Enrollment intensity",
+      "Year-1 GPA band",
+      "English placement / readiness indicators",
+      "Program of study",
+    ],
+    trainingData: {
+      source: "Bishop State Community College historical PDP submissions",
+      cohort: "Cohorts 2018-2022 with observed gateway English completion",
+      rowCount: "~4,000 students",
+    },
+    runsOn: "On-premise / institution-controlled infrastructure.",
+    dataFlow: "Local-only inference; probability written to `student_predictions`.",
+    retentionPolicy: "Predictions stored in `student_predictions`. No third-party data flow.",
+  },
+  {
+    id: "low-gpa",
+    name: "First-Semester Low-GPA Prediction",
+    status: "deployed",
+    category: "ml_model",
+    homegrown: true,
+    provider: null,
+    algorithm: "XGBoost classifier",
+    version: "1.0",
+    inputs: [
+      "Cohort year and term",
+      "Enrollment intensity",
+      "Pell eligibility",
+      "First-generation status",
+      "Program of study",
+      "Pre-enrollment readiness indicators",
+    ],
+    trainingData: {
+      source: "Bishop State Community College historical PDP submissions",
+      cohort: "Cohorts 2018-2022 with observed first-semester GPA",
+      rowCount: "~4,000 students",
+    },
+    runsOn: "On-premise / institution-controlled infrastructure.",
+    dataFlow: "Local-only inference; probability written to `student_predictions`.",
+    retentionPolicy: "Predictions stored in `student_predictions`. No third-party data flow.",
+  },
+
+  // ─────────────────────────── Natural-language surfaces (3 LLM-backed + 1 rule-based fallback) ───────────────────────────
+  {
+    id: "nlq-analyzer",
+    name: "Natural-Language Query Analyzer (Prompt → SQL)",
+    status: "deployed",
+    category: "natural_language",
+    homegrown: false,
+    provider: "OpenAI",
+    algorithm: "OpenAI gpt-4o-mini via the Vercel AI SDK (`@ai-sdk/openai`), called with a structured-output schema (Zod) to generate a query plan and SQL.",
+    version: "gpt-4o-mini (OpenAI model snapshot at request time)",
+    inputs: [
+      "The user's natural-language prompt as typed in `/query`",
+      "The database schema description for the institution (table names, column names, column descriptions) — embedded in the prompt template at `app/api/analyze/route.ts`",
+      "The institution code (e.g., `bscc`)",
+    ],
+    trainingData: null,
+    runsOn:
+      "Inference runs on OpenAI's infrastructure. The dashboard server (Next.js API route at `/api/analyze`) is the caller; the API key is held server-side only.",
+    dataFlow:
+      "When a user submits a natural-language query: (1) the prompt is sent from the browser to our `/api/analyze` route. (2) The route sends the user prompt + the institution's schema description + few-shot SQL examples to OpenAI's chat completions API (`gpt-4o-mini`). (3) OpenAI returns a structured query plan, including the SQL to execute. (4) The SQL is then executed against the institution's database (no further OpenAI involvement).\n\nNo student-level row data is sent to OpenAI — only the schema description (column names + plain-English column descriptions). The user's prompt itself is sent verbatim. Student_GUID is explicitly listed as FERPA-excluded in the prompt template.",
+    retentionPolicy:
+      "OpenAI's API data-handling policy applies to the prompt and schema description. As of this writing, OpenAI states that data submitted via the API is not used to train their models. We do not separately log prompts or responses to a third-party store.",
+    notes:
+      "If `OPENAI_API_KEY` is not configured, the route returns a 500 error and the client falls back to the rule-based analyzer (`prompt-analyzer.ts`, see next entry).",
+  },
+  {
+    id: "nlq-rule-based-fallback",
+    name: "Natural-Language Query — Rule-Based Fallback",
+    status: "deployed",
+    category: "natural_language",
+    homegrown: true,
+    provider: null,
+    algorithm:
+      "Hand-rolled keyword matcher in `codebenders-dashboard/lib/prompt-analyzer.ts`. The prompt is lowercased and checked against a fixed set of substrings (e.g., `\"retention\"`, `\"by cohort\"`, `\"2024\"`) which map to a `metric`, `groupBy`, and `filters` shape.",
+    version: "1.0",
+    inputs: [
+      "The user's natural-language prompt (lowercased and substring-matched only)",
+      "The institution code (used to construct the data-API URL)",
+    ],
+    trainingData: null,
+    runsOn: "Runs in the user's browser. No outbound network call by the analyzer itself.",
+    dataFlow:
+      "Pure local string matching. The analyzer does not transmit the prompt anywhere. It produces a query plan; the resulting query is then executed against either the local API (`/api/execute-sql`) or the external `schools.syntex-ai.com` data API (see Data API entry).",
+    retentionPolicy: "Nothing is retained by the analyzer.",
+    notes:
+      "Used as a fallback for the LLM-backed analyzer when OpenAI is unavailable or when running in offline / cost-sensitive contexts. Coverage is narrow — recognizes a fixed list of keywords. Outside that set, results degrade to a generic COUNT(*) query.",
+  },
+  {
+    id: "query-summary",
+    name: "Query Result Summarizer",
+    status: "deployed",
+    category: "natural_language",
+    homegrown: false,
+    provider: "OpenAI",
+    algorithm: "OpenAI gpt-4o-mini, called from `/api/query-summary` to generate a short narrative summary of a tabular query result.",
+    version: "gpt-4o-mini",
+    inputs: [
+      "The user's original prompt",
+      "Up to N capped rows of the SQL query result (rows are capped server-side before transmission to limit token usage and bound exposure)",
+    ],
+    trainingData: null,
+    runsOn:
+      "Inference on OpenAI infrastructure. Caller is the dashboard server route at `app/api/query-summary/route.ts`.",
+    dataFlow:
+      "The capped result rows + the user's prompt are sent to OpenAI's chat completions API. The narrative summary returned by OpenAI is rendered in the UI. Whether row contents include student-level data depends on the SQL the analyzer produced — Student_GUID is FERPA-excluded by prompt design, but other student attributes may appear in result rows depending on the query.",
+    retentionPolicy:
+      "OpenAI API data-handling policy applies. We do not log prompts/responses to a separate third-party store.",
+    notes:
+      "This is the highest-sensitivity OpenAI surface in the system because *result rows* (not just schema) are transmitted. Institutions evaluating procurement should review the row cap and the query-design FERPA exclusions in `/api/analyze/route.ts`.",
+  },
+  {
+    id: "explain-pairing",
+    name: "Course-Pairing Explainer",
+    status: "deployed",
+    category: "natural_language",
+    homegrown: false,
+    provider: "OpenAI",
+    algorithm:
+      "OpenAI gpt-4o-mini, called from `/api/courses/explain-pairing` to generate a natural-language explanation of why two courses appear to be paired (co-enrollment patterns, sequencing, success-rate correlation).",
+    version: "gpt-4o-mini",
+    inputs: [
+      "Two course identifiers (prefix + number)",
+      "Aggregated co-enrollment statistics for the pair (counts, success rates, sequencing) computed server-side before transmission",
+    ],
+    trainingData: null,
+    runsOn: "Inference on OpenAI infrastructure. Caller is the dashboard server route.",
+    dataFlow:
+      "Pre-aggregated, course-level statistics (no student-level rows) are sent to OpenAI along with the prompt template. The natural-language explanation is rendered in the UI.",
+    retentionPolicy:
+      "OpenAI API data-handling policy applies. No separate third-party logging.",
+    notes:
+      "Student-level data is NOT sent for this surface — only course-pair aggregates.",
+  },
+
+  // ─────────────────────────── Data API (third-party host) ───────────────────────────
+  {
+    id: "syntex-data-api",
+    name: "External Analysis-Ready Data API",
+    status: "deployed",
+    category: "data_api",
+    homegrown: false,
+    provider: "schools.syntex-ai.com (project-controlled hosting; not the institution's own infrastructure)",
+    algorithm:
+      "REST endpoint that returns analysis-ready rows for a given institution and filter set. Not an AI model — included on this page because student data flows to a non-institutional host.",
+    version: "live API; no version pin",
+    inputs: [
+      "Institution code in the URL path (e.g., `bscc`, `akron`)",
+      "Filter parameters (cohort, enrollment_status, etc.)",
+      "Pagination (`limit`, `offset`)",
+    ],
+    trainingData: null,
+    runsOn: "schools.syntex-ai.com — hosted by the project team, not by the institution.",
+    dataFlow:
+      "When the dashboard is run in `useDirectDB = false` mode (default for some query paths in `lib/query-executor.ts`), query plans are converted into URL parameters and fetched from `https://schools.syntex-ai.com/<institution>/analysis-ready`. The API returns analysis-ready rows that the dashboard then groups/aggregates client-side.\n\nWhen `useDirectDB = true`, queries go to the local `/api/execute-sql` route instead and never reach syntex-ai.com.",
+    retentionPolicy:
+      "Logging and retention at schools.syntex-ai.com are governed by the project deployment, not by the institution. Institutions evaluating procurement should ask whether their deployment uses direct-DB mode or the external API.",
+    notes:
+      "This entry exists for full-stack transparency: institutions deploying this dashboard should know that, in default configuration for some queries, student-level rows are returned from a non-institutional host. A deployment hardening option to force `useDirectDB = true` end-to-end is tracked as a follow-up issue.",
+  },
+
+  // ─────────────────────────── In-development ───────────────────────────
+  {
+    id: "shap-narrator",
+    name: "SHAP Narrator (Per-Student Explanations)",
+    status: "in_development",
+    category: "explainability",
+    homegrown: true,
+    provider: null,
+    algorithm:
+      "Fine-tuned small language model (Qwen 3.5-4B / Gemma 4 E4B candidates) generating natural-language explanations from SHAP feature attributions over the deployed XGBoost / Random Forest models.",
+    version: "0.1 (in development — not yet deployed)",
+    inputs: [
+      "SHAP feature-attribution values from the deployed models",
+      "Student demographic and academic features (same set as the underlying prediction)",
+      "Prediction outcome (e.g., 'at risk' / 'on track')",
+    ],
+    trainingData: {
+      source:
+        "Distillation pairs generated from a teacher model over Bishop State predictions; tracked in issues #97, #99, #100.",
+      cohort: "Bishop State student predictions (training-only).",
+    },
+    runsOn:
+      "Planned: on-premise / institution-controlled inference. Final hosting decision tracked in issues #101, #102.",
+    dataFlow:
+      "When deployed: SHAP values + features go in locally, natural-language explanation comes out locally — no third-party inference API. During DEVELOPMENT only, training-data distillation passes through Colab notebooks (issue #98). The dashboard does NOT show SHAP-narrated explanations to users today.",
+    retentionPolicy:
+      "Not yet deployed. When deployed, generated explanations will be stored alongside the underlying prediction. No third-party storage planned.",
+    notes:
+      "Listed here for full lifecycle transparency. Institutions evaluating procurement should know what is coming as well as what is running.",
+  },
+]

--- a/codebenders-dashboard/content/ai-transparency.ts
+++ b/codebenders-dashboard/content/ai-transparency.ts
@@ -33,6 +33,32 @@ export interface AISurface {
   notes?: string
 }
 
+/** App route for the AI Transparency page (nav and cross-links). */
+export const AI_TRANSPARENCY_HREF = "/ai-transparency" as const
+
+/** Category sections on the page appear in this order; keep in sync with grouping logic. */
+export const AI_SURFACE_CATEGORY_ORDER: AISurface["category"][] = [
+  "ml_model",
+  "natural_language",
+  "data_api",
+  "explainability",
+]
+
+export function groupAISurfacesByCategory(
+  surfaces: readonly AISurface[]
+): Record<AISurface["category"], AISurface[]> {
+  const grouped: Record<AISurface["category"], AISurface[]> = {
+    ml_model: [],
+    natural_language: [],
+    explainability: [],
+    data_api: [],
+  }
+  for (const surface of surfaces) {
+    grouped[surface.category].push(surface)
+  }
+  return grouped
+}
+
 export const AI_SURFACES: AISurface[] = [
   // ─────────────────────────── ML models (6, all homegrown) ───────────────────────────
   {


### PR DESCRIPTION
## Summary

Adds `/ai-transparency` listing every AI or AI-adjacent surface running in the dashboard, with: algorithm, inputs, training data (if any), where the inference runs, what data flows on invocation, and the retention policy. Closes #108.

## What's inventoried

- **6 homegrown ML models** (XGBoost / Random Forest, all on-prem, no third-party data flow): retention, time-to-credential, credential type, gateway math, gateway English, low GPA.
- **3 OpenAI gpt-4o-mini routes** with explicit data-flow disclosures: prompt→SQL analyzer (`app/api/analyze`), query-result summarizer (`app/api/query-summary`), course-pairing explainer (`app/api/courses/explain-pairing`).
- **1 rule-based NLQ fallback** at `lib/prompt-analyzer.ts` (no LLM, no outbound flow).
- **1 external data API** at `schools.syntex-ai.com` — disclosed honestly, even though it's project-controlled, because it isn't on the institution's infrastructure.
- **1 in-development entry** for the SHAP narrator.

## Discoveries that shaped the disclosures

- `CLAUDE.md` and `README.md` claimed *"5 ML models"* and *"OpenAI for natural language query analysis"* — both inaccurate. The pipeline trains 6 models, and there are 3 distinct OpenAI routes (not just one). Filed #125 to fix the docs.
- The default query path can hit `schools.syntex-ai.com` even when a local DB is configured. Filed #126 to add a `FORCE_DIRECT_DB` flag for institutions that need a fully-local data path.
- FERPA exclusion (`Student_GUID`) is enforced by prompt only, not by code. Filed #127 to add a runtime guard + test suite.

## Implementation notes

- Content lives in `codebenders-dashboard/content/ai-transparency.ts` as a typed `AISurface[]`. Chose typed TSX over markdown because (a) the codebase convention (`/methodology` is the precedent) is structured TSX with content arrays, (b) typed entries enforce required disclosure fields at compile time — the failure mode of a transparency page is omission, and TS catches that, markdown can't.
- Page is linked from `nav-header.tsx` (visible to all roles) and from a new "See also" section at the bottom of `/methodology`.
- No new dependencies.

## Test plan

- [ ] `npm run dev` and navigate to `/ai-transparency`; verify all entries render
- [ ] Click "AI Transparency" in the nav header from each route
- [ ] Visit `/methodology` and follow the new cross-link
- [ ] Confirm `Deployed` vs `In development` badges render correctly
- [ ] Confirm `Homegrown` vs `Third-party: <provider>` badges render correctly
- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes

## Related

- Part of #124 (spring-convening-followup epic)
- Filed during this PR: #125 (docs drift), #126 (FORCE_DIRECT_DB hardening flag), #127 (FERPA exclusion runtime guard)

## Deviations from acceptance criteria in #108

- "Markdown-sourced for easy maintenance" → typed TS module instead. Reasoning above. Same maintainability win, no new dep, matches codebase, gives compile-time guarantees that markdown can't.
- "Linked from the dashboard footer" → there is no global footer in the app. Linked from the nav header instead, plus from `/methodology`. Equivalent reachability.