### PR TITLE
feat(dashboard): presentation-ready chart export PNG/PDF with glossary (#106)

### DIFF
--- a/codebenders-dashboard/components/chart-export-card-meta.tsx
+++ b/codebenders-dashboard/components/chart-export-card-meta.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import type { ReactElement, ReactNode } from "react"
+
+import { CardFooter } from "@/components/ui/card"
+import type { MetricGlossarySlug } from "@/lib/glossary-constants"
+import { CHART_EXPORT_BRAND_LINE } from "@/lib/chart-export-filename"
+import { getChartExportBlurb } from "@/lib/chart-export-glossary"
+
+export function ChartExportGlossaryBlurb(props: { slug: MetricGlossarySlug }): ReactElement {
+  return (
+    <p className="text-xs text-muted-foreground leading-snug max-w-prose">
+      {getChartExportBlurb(props.slug)}
+    </p>
+  )
+}
+
+export function ChartExportDataSourceLine(props: { children: ReactNode }): ReactElement {
+  return (
+    <p className="text-xs text-muted-foreground">
+      <span className="font-medium text-foreground/90">Data source:</span> {props.children}{" "}
+      <span className="font-medium text-foreground/90">Generated:</span>{" "}
+      {new Date().toLocaleDateString()}
+    </p>
+  )
+}
+
+export function ChartExportBrandFooter(): ReactElement {
+  return (
+    <CardFooter className="border-t border-border pt-6 text-xs text-muted-foreground">
+      {CHART_EXPORT_BRAND_LINE}
+    </CardFooter>
+  )
+}

--- a/codebenders-dashboard/components/chart-export-menu.tsx
+++ b/codebenders-dashboard/components/chart-export-menu.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { Download, FileImage, FileSpreadsheet, FileType } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { buildChartExportBasename } from "@/lib/chart-export-filename"
+import { captureElementToPngDataUrl, downloadChartPdf, downloadDataUrl } from "@/lib/chart-export-capture"
+
+export interface ChartExportCsvSpec {
+  headers: string[]
+  rows: (string | number)[][]
+}
+
+interface ChartExportMenuProps {
+  exportRef: React.RefObject<HTMLElement | null>
+  chartFileSlug: string
+  csv?: ChartExportCsvSpec | null
+  disabled?: boolean
+  /** Report capture failures (e.g. toast); defaults to console.error */
+  onError?: (message: string) => void
+}
+
+function escapeCsvCell(v: string | number): string {
+  const s = String(v)
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`
+  return s
+}
+
+function downloadChartCsv(spec: ChartExportCsvSpec, basename: string): void {
+  const lines = [
+    spec.headers.map(escapeCsvCell).join(","),
+    ...spec.rows.map((row) => row.map(escapeCsvCell).join(",")),
+  ]
+  const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8" })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = `${basename}.csv`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+export function ChartExportMenu({
+  exportRef,
+  chartFileSlug,
+  csv,
+  disabled = false,
+  onError,
+}: ChartExportMenuProps) {
+  const [busy, setBusy] = useState(false)
+
+  const runExport = useCallback(
+    async (kind: "png" | "pdf") => {
+      const report = onError ?? ((m: string) => console.error(m))
+      const el = exportRef.current
+      if (!el) {
+        report("Chart export: missing element")
+        return
+      }
+      setBusy(true)
+      try {
+        const basename = buildChartExportBasename(chartFileSlug)
+        if (kind === "png") {
+          const dataUrl = await captureElementToPngDataUrl(el)
+          downloadDataUrl(dataUrl, `${basename}.png`)
+        } else {
+          await downloadChartPdf(el, `${basename}.pdf`)
+        }
+      } catch (e) {
+        report(e instanceof Error ? e.message : "Chart export failed")
+      } finally {
+        setBusy(false)
+      }
+    },
+    [chartFileSlug, exportRef, onError]
+  )
+
+  const onCsv = useCallback(() => {
+    if (!csv) return
+    const basename = buildChartExportBasename(chartFileSlug)
+    downloadChartCsv(csv, basename)
+  }, [chartFileSlug, csv])
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-1 h-8"
+          disabled={disabled || busy}
+          data-chart-export-exclude
+          aria-label="Export chart"
+        >
+          <Download className="h-3.5 w-3.5" />
+          Export
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuLabel>Export chart</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {csv ? (
+          <DropdownMenuItem onClick={onCsv} className="gap-2">
+            <FileSpreadsheet className="h-4 w-4" />
+            CSV
+          </DropdownMenuItem>
+        ) : null}
+        <DropdownMenuItem
+          onClick={() => void runExport("png")}
+          disabled={busy}
+          className="gap-2"
+        >
+          <FileImage className="h-4 w-4" />
+          PNG
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => void runExport("pdf")}
+          disabled={busy}
+          className="gap-2"
+        >
+          <FileType className="h-4 w-4" />
+          PDF
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/codebenders-dashboard/components/chart-export-menu.tsx
+++ b/codebenders-dashboard/components/chart-export-menu.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useState } from "react"
+import { useCallback, useState, type RefObject } from "react"
 import { Download, FileImage, FileSpreadsheet, FileType } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -12,42 +12,21 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { buildChartExportBasename } from "@/lib/chart-export-filename"
-import { captureElementToPngDataUrl, downloadChartPdf, downloadDataUrl } from "@/lib/chart-export-capture"
-
-export interface ChartExportCsvSpec {
-  headers: string[]
-  rows: (string | number)[][]
-}
+import {
+  captureElementToPngDataUrl,
+  downloadChartExportCsv,
+  downloadChartPdf,
+  downloadDataUrl,
+} from "@/lib/chart-export-capture"
+import type { ChartExportCsvSpec } from "@/lib/chart-export-csv"
 
 interface ChartExportMenuProps {
-  exportRef: React.RefObject<HTMLElement | null>
+  exportRef: RefObject<HTMLElement | null>
   chartFileSlug: string
   csv?: ChartExportCsvSpec | null
   disabled?: boolean
   /** Report capture failures (e.g. toast); defaults to console.error */
   onError?: (message: string) => void
-}
-
-function escapeCsvCell(v: string | number): string {
-  const s = String(v)
-  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`
-  return s
-}
-
-function downloadChartCsv(spec: ChartExportCsvSpec, basename: string): void {
-  const lines = [
-    spec.headers.map(escapeCsvCell).join(","),
-    ...spec.rows.map((row) => row.map(escapeCsvCell).join(",")),
-  ]
-  const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8" })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement("a")
-  a.href = url
-  a.download = `${basename}.csv`
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  URL.revokeObjectURL(url)
 }
 
 export function ChartExportMenu({
@@ -88,7 +67,7 @@ export function ChartExportMenu({
   const onCsv = useCallback(() => {
     if (!csv) return
     const basename = buildChartExportBasename(chartFileSlug)
-    downloadChartCsv(csv, basename)
+    downloadChartExportCsv(csv, `${basename}.csv`)
   }, [chartFileSlug, csv])
 
   return (

--- a/codebenders-dashboard/components/readiness-assessment-chart.tsx
+++ b/codebenders-dashboard/components/readiness-assessment-chart.tsx
@@ -6,7 +6,6 @@ import {
   CardAction,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
@@ -15,9 +14,12 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertCircle, TrendingUp, Users, Target, AlertTriangle } from 'lucide-react';
 import { InfoPopover } from '@/components/info-popover';
 import { GlossaryMetricEntryLink } from '@/components/glossary-metric-entry-link';
+import {
+  ChartExportBrandFooter,
+  ChartExportDataSourceLine,
+  ChartExportGlossaryBlurb,
+} from '@/components/chart-export-card-meta';
 import { ChartExportMenu } from '@/components/chart-export-menu';
-import { getChartExportBlurb } from '@/lib/chart-export-glossary';
-import { CHART_EXPORT_BRAND_LINE } from '@/lib/chart-export-filename';
 
 interface ReadinessData {
   summary: {
@@ -71,6 +73,9 @@ interface ReadinessAssessmentChartProps {
   isLoading?: boolean;
   error?: string;
 }
+
+const READINESS_LEVEL_CHART_SLUG = 'readiness-level-distribution' as const;
+const READINESS_SCORE_CHART_SLUG = 'readiness-score-distribution' as const;
 
 export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAssessmentChartProps) {
   const levelDistExportRef = useRef<HTMLDivElement>(null);
@@ -222,14 +227,10 @@ export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAs
         <CardHeader>
           <CardTitle>Readiness Level Distribution</CardTitle>
           <CardDescription>Student readiness categorization</CardDescription>
-          <p className="text-xs text-muted-foreground leading-snug max-w-prose">
-            {getChartExportBlurb('readiness-assessment')}
-          </p>
-          <p className="text-xs text-muted-foreground">
-            <span className="font-medium text-foreground/90">Data source:</span> /api/dashboard/readiness ·
-            student_level_with_predictions ·{' '}
-            <span className="font-medium text-foreground/90">Generated:</span> {new Date().toLocaleDateString()}
-          </p>
+          <ChartExportGlossaryBlurb slug="readiness-assessment" />
+          <ChartExportDataSourceLine>
+            /api/dashboard/readiness · student_level_with_predictions ·
+          </ChartExportDataSourceLine>
           <CardAction>
             <div className="flex items-center gap-1">
               <span data-chart-export-exclude>
@@ -243,7 +244,7 @@ export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAs
               </span>
               <ChartExportMenu
                 exportRef={levelDistExportRef}
-                chartFileSlug="readiness-level-distribution"
+                chartFileSlug={READINESS_LEVEL_CHART_SLUG}
                 csv={levelCsvSpec}
               />
             </div>
@@ -281,9 +282,7 @@ export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAs
             })}
           </div>
         </CardContent>
-        <CardFooter className="border-t border-border pt-6 text-xs text-muted-foreground">
-          {CHART_EXPORT_BRAND_LINE}
-        </CardFooter>
+        <ChartExportBrandFooter />
       </Card>
 
       {/* Score Distribution */}
@@ -291,18 +290,14 @@ export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAs
         <CardHeader>
           <CardTitle>Score Distribution</CardTitle>
           <CardDescription>Readiness scores grouped by range</CardDescription>
-          <p className="text-xs text-muted-foreground leading-snug max-w-prose">
-            {getChartExportBlurb('readiness-assessment')}
-          </p>
-          <p className="text-xs text-muted-foreground">
-            <span className="font-medium text-foreground/90">Data source:</span> /api/dashboard/readiness ·
-            student_level_with_predictions ·{' '}
-            <span className="font-medium text-foreground/90">Generated:</span> {new Date().toLocaleDateString()}
-          </p>
+          <ChartExportGlossaryBlurb slug="readiness-assessment" />
+          <ChartExportDataSourceLine>
+            /api/dashboard/readiness · student_level_with_predictions ·
+          </ChartExportDataSourceLine>
           <CardAction>
             <ChartExportMenu
               exportRef={scoreDistExportRef}
-              chartFileSlug="readiness-score-distribution"
+              chartFileSlug={READINESS_SCORE_CHART_SLUG}
               csv={scoreCsvSpec}
             />
           </CardAction>
@@ -331,9 +326,7 @@ export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAs
             })}
           </div>
         </CardContent>
-        <CardFooter className="border-t border-border pt-6 text-xs text-muted-foreground">
-          {CHART_EXPORT_BRAND_LINE}
-        </CardFooter>
+        <ChartExportBrandFooter />
       </Card>
 
       {/* Top Risk Factors */}

--- a/codebenders-dashboard/components/readiness-assessment-chart.tsx
+++ b/codebenders-dashboard/components/readiness-assessment-chart.tsx
@@ -1,11 +1,23 @@
 'use client';
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useMemo, useRef } from 'react';
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertCircle, TrendingUp, Users, Target, AlertTriangle } from 'lucide-react';
 import { InfoPopover } from '@/components/info-popover';
 import { GlossaryMetricEntryLink } from '@/components/glossary-metric-entry-link';
+import { ChartExportMenu } from '@/components/chart-export-menu';
+import { getChartExportBlurb } from '@/lib/chart-export-glossary';
+import { CHART_EXPORT_BRAND_LINE } from '@/lib/chart-export-filename';
 
 interface ReadinessData {
   summary: {
@@ -61,6 +73,33 @@ interface ReadinessAssessmentChartProps {
 }
 
 export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAssessmentChartProps) {
+  const levelDistExportRef = useRef<HTMLDivElement>(null);
+  const scoreDistExportRef = useRef<HTMLDivElement>(null);
+
+  const levelCsvSpec = useMemo(() => {
+    if (!data?.distribution?.length) return null;
+    const total = data.summary.total_students;
+    return {
+      headers: ['Readiness level', 'Count', 'Avg score (0-1)', 'Percent of cohort'],
+      rows: data.distribution.map((level) => {
+        const pct = total > 0 ? `${((level.count / total) * 100).toFixed(1)}%` : '0%';
+        return [level.readiness_level, level.count, level.avg_score, pct];
+      }),
+    };
+  }, [data]);
+
+  const scoreCsvSpec = useMemo(() => {
+    if (!data?.score_distribution?.length) return null;
+    const total = data.summary.total_students;
+    return {
+      headers: ['Score range', 'Count', 'Percent of cohort'],
+      rows: data.score_distribution.map((row) => {
+        const pct = total > 0 ? `${((row.count / total) * 100).toFixed(1)}%` : '0%';
+        return [row.score_range, row.count, pct];
+      }),
+    };
+  }, [data]);
+
   if (isLoading) {
     return (
       <Card className="w-full">
@@ -117,7 +156,6 @@ export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAs
   const totalStudents = summary.total_students;
   const avgScore = parseFloat(summary.avg_score);
   const highPct = totalStudents > 0 ? ((summary.high_count / totalStudents) * 100).toFixed(1) : '0';
-  const mediumPct = totalStudents > 0 ? ((summary.medium_count / totalStudents) * 100).toFixed(1) : '0';
   const lowPct = totalStudents > 0 ? ((summary.low_count / totalStudents) * 100).toFixed(1) : '0';
 
   return (
@@ -180,21 +218,36 @@ export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAs
       </div>
 
       {/* Readiness Level Distribution */}
-      <Card>
+      <Card ref={levelDistExportRef}>
         <CardHeader>
-          <div className="flex items-center justify-between">
-            <div>
-              <CardTitle>Readiness Level Distribution</CardTitle>
-              <CardDescription>Student readiness categorization</CardDescription>
+          <CardTitle>Readiness Level Distribution</CardTitle>
+          <CardDescription>Student readiness categorization</CardDescription>
+          <p className="text-xs text-muted-foreground leading-snug max-w-prose">
+            {getChartExportBlurb('readiness-assessment')}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            <span className="font-medium text-foreground/90">Data source:</span> /api/dashboard/readiness ·
+            student_level_with_predictions ·{' '}
+            <span className="font-medium text-foreground/90">Generated:</span> {new Date().toLocaleDateString()}
+          </p>
+          <CardAction>
+            <div className="flex items-center gap-1">
+              <span data-chart-export-exclude>
+                <InfoPopover title="Readiness Assessment">
+                  <p>
+                    AI-powered assessment analyzing student preparation, engagement, and success indicators. High
+                    readiness indicates students are well-positioned for success.
+                  </p>
+                  <GlossaryMetricEntryLink slug="readiness-assessment" />
+                </InfoPopover>
+              </span>
+              <ChartExportMenu
+                exportRef={levelDistExportRef}
+                chartFileSlug="readiness-level-distribution"
+                csv={levelCsvSpec}
+              />
             </div>
-            <InfoPopover title="Readiness Assessment">
-              <p>
-                AI-powered assessment analyzing student preparation, engagement, and success indicators. High readiness
-                indicates students are well-positioned for success.
-              </p>
-              <GlossaryMetricEntryLink slug="readiness-assessment" />
-            </InfoPopover>
-          </div>
+          </CardAction>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
@@ -228,13 +281,31 @@ export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAs
             })}
           </div>
         </CardContent>
+        <CardFooter className="border-t border-border pt-6 text-xs text-muted-foreground">
+          {CHART_EXPORT_BRAND_LINE}
+        </CardFooter>
       </Card>
 
       {/* Score Distribution */}
-      <Card>
+      <Card ref={scoreDistExportRef}>
         <CardHeader>
           <CardTitle>Score Distribution</CardTitle>
           <CardDescription>Readiness scores grouped by range</CardDescription>
+          <p className="text-xs text-muted-foreground leading-snug max-w-prose">
+            {getChartExportBlurb('readiness-assessment')}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            <span className="font-medium text-foreground/90">Data source:</span> /api/dashboard/readiness ·
+            student_level_with_predictions ·{' '}
+            <span className="font-medium text-foreground/90">Generated:</span> {new Date().toLocaleDateString()}
+          </p>
+          <CardAction>
+            <ChartExportMenu
+              exportRef={scoreDistExportRef}
+              chartFileSlug="readiness-score-distribution"
+              csv={scoreCsvSpec}
+            />
+          </CardAction>
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
@@ -260,6 +331,9 @@ export function ReadinessAssessmentChart({ data, isLoading, error }: ReadinessAs
             })}
           </div>
         </CardContent>
+        <CardFooter className="border-t border-border pt-6 text-xs text-muted-foreground">
+          {CHART_EXPORT_BRAND_LINE}
+        </CardFooter>
       </Card>
 
       {/* Top Risk Factors */}

--- a/codebenders-dashboard/components/retention-risk-chart.tsx
+++ b/codebenders-dashboard/components/retention-risk-chart.tsx
@@ -1,8 +1,12 @@
 "use client"
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { useMemo, useRef } from "react"
+import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from "recharts"
 import { InfoPopover } from "@/components/info-popover"
+import { ChartExportMenu } from "@/components/chart-export-menu"
+import { getChartExportBlurb } from "@/lib/chart-export-glossary"
+import { CHART_EXPORT_BRAND_LINE } from "@/lib/chart-export-filename"
 
 interface RetentionRiskData {
   category: string
@@ -23,7 +27,22 @@ const COLORS = {
   "Low Risk": "#22c55e",        // green
 }
 
+const CHART_FILE_SLUG = "retention-risk-funnel" as const
+
 export function RetentionRiskChart({ data, loading = false, info }: RetentionRiskChartProps) {
+  const exportRef = useRef<HTMLDivElement>(null)
+
+  const csvSpec = useMemo(
+    () =>
+      data?.length
+        ? {
+            headers: ["Risk Category", "Count", "Percentage"],
+            rows: data.map((d) => [d.category, d.count, `${Number(d.percentage).toFixed(1)}%`]),
+          }
+        : null,
+    [data]
+  )
+
   if (loading) {
     return (
       <Card>
@@ -68,16 +87,36 @@ export function RetentionRiskChart({ data, loading = false, info }: RetentionRis
     percentage: item.percentage,
   }))
 
+  const totalStudents = data.reduce((sum, item) => sum + Number(item.count), 0)
+
   return (
-    <Card>
+    <Card ref={exportRef}>
       <CardHeader>
-        <div className="flex items-center">
-          <CardTitle>Retention Risk Funnel</CardTitle>
-          {info && <InfoPopover title="Retention Risk Funnel">{info}</InfoPopover>}
-        </div>
-        <CardDescription>
-          {data.reduce((sum, item) => sum + Number(item.count), 0).toLocaleString()} total students
-        </CardDescription>
+        <CardTitle>Retention Risk Funnel</CardTitle>
+        <CardDescription>{totalStudents.toLocaleString()} total students</CardDescription>
+        <p className="text-xs text-muted-foreground leading-snug max-w-prose">
+          {getChartExportBlurb("retention-risk-funnel")}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground/90">Data source:</span>{" "}
+          student_level_with_predictions · retention_probability (XGBoost) ·{" "}
+          <span className="font-medium text-foreground/90">Generated:</span>{" "}
+          {new Date().toLocaleDateString()}
+        </p>
+        <CardAction>
+          <div className="flex items-center gap-1">
+            {info ? (
+              <span data-chart-export-exclude>
+                <InfoPopover title="Retention Risk Funnel">{info}</InfoPopover>
+              </span>
+            ) : null}
+            <ChartExportMenu
+              exportRef={exportRef}
+              chartFileSlug={CHART_FILE_SLUG}
+              csv={csvSpec}
+            />
+          </div>
+        </CardAction>
       </CardHeader>
       <CardContent>
         <ResponsiveContainer width="100%" height={300}>
@@ -119,6 +158,9 @@ export function RetentionRiskChart({ data, loading = false, info }: RetentionRis
           </BarChart>
         </ResponsiveContainer>
       </CardContent>
+      <CardFooter className="border-t border-border pt-6 text-xs text-muted-foreground">
+        {CHART_EXPORT_BRAND_LINE}
+      </CardFooter>
     </Card>
   )
 }

--- a/codebenders-dashboard/components/retention-risk-chart.tsx
+++ b/codebenders-dashboard/components/retention-risk-chart.tsx
@@ -1,12 +1,16 @@
 "use client"
 
 import { useMemo, useRef } from "react"
-import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from "recharts"
 import { InfoPopover } from "@/components/info-popover"
+import {
+  ChartExportBrandFooter,
+  ChartExportDataSourceLine,
+  ChartExportGlossaryBlurb,
+} from "@/components/chart-export-card-meta"
 import { ChartExportMenu } from "@/components/chart-export-menu"
-import { getChartExportBlurb } from "@/lib/chart-export-glossary"
-import { CHART_EXPORT_BRAND_LINE } from "@/lib/chart-export-filename"
+import { buildCategoryCountPercentageCsv } from "@/lib/chart-export-csv"
 
 interface RetentionRiskData {
   category: string
@@ -34,12 +38,7 @@ export function RetentionRiskChart({ data, loading = false, info }: RetentionRis
 
   const csvSpec = useMemo(
     () =>
-      data?.length
-        ? {
-            headers: ["Risk Category", "Count", "Percentage"],
-            rows: data.map((d) => [d.category, d.count, `${Number(d.percentage).toFixed(1)}%`]),
-          }
-        : null,
+      buildCategoryCountPercentageCsv(data, ["Risk Category", "Count", "Percentage"] as const),
     [data]
   )
 
@@ -94,15 +93,10 @@ export function RetentionRiskChart({ data, loading = false, info }: RetentionRis
       <CardHeader>
         <CardTitle>Retention Risk Funnel</CardTitle>
         <CardDescription>{totalStudents.toLocaleString()} total students</CardDescription>
-        <p className="text-xs text-muted-foreground leading-snug max-w-prose">
-          {getChartExportBlurb("retention-risk-funnel")}
-        </p>
-        <p className="text-xs text-muted-foreground">
-          <span className="font-medium text-foreground/90">Data source:</span>{" "}
-          student_level_with_predictions · retention_probability (XGBoost) ·{" "}
-          <span className="font-medium text-foreground/90">Generated:</span>{" "}
-          {new Date().toLocaleDateString()}
-        </p>
+        <ChartExportGlossaryBlurb slug="retention-risk-funnel" />
+        <ChartExportDataSourceLine>
+          student_level_with_predictions · retention_probability (XGBoost) ·
+        </ChartExportDataSourceLine>
         <CardAction>
           <div className="flex items-center gap-1">
             {info ? (
@@ -158,9 +152,7 @@ export function RetentionRiskChart({ data, loading = false, info }: RetentionRis
           </BarChart>
         </ResponsiveContainer>
       </CardContent>
-      <CardFooter className="border-t border-border pt-6 text-xs text-muted-foreground">
-        {CHART_EXPORT_BRAND_LINE}
-      </CardFooter>
+      <ChartExportBrandFooter />
     </Card>
   )
 }

--- a/codebenders-dashboard/components/risk-alert-chart.tsx
+++ b/codebenders-dashboard/components/risk-alert-chart.tsx
@@ -1,12 +1,16 @@
 "use client"
 
 import { useMemo, useRef } from "react"
-import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from "recharts"
 import { InfoPopover } from "@/components/info-popover"
+import {
+  ChartExportBrandFooter,
+  ChartExportDataSourceLine,
+  ChartExportGlossaryBlurb,
+} from "@/components/chart-export-card-meta"
 import { ChartExportMenu } from "@/components/chart-export-menu"
-import { getChartExportBlurb } from "@/lib/chart-export-glossary"
-import { CHART_EXPORT_BRAND_LINE } from "@/lib/chart-export-filename"
+import { buildCategoryCountPercentageCsv } from "@/lib/chart-export-csv"
 
 interface RiskAlertData {
   category: string
@@ -54,12 +58,7 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
 
   const csvSpec = useMemo(
     () =>
-      data?.length
-        ? {
-            headers: ["Alert Level", "Count", "Percentage"],
-            rows: data.map((d) => [d.category, d.count, `${Number(d.percentage).toFixed(1)}%`]),
-          }
-        : null,
+      buildCategoryCountPercentageCsv(data, ["Alert Level", "Count", "Percentage"] as const),
     [data]
   )
 
@@ -114,15 +113,10 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
       <CardHeader>
         <CardTitle>Risk Alert Distribution</CardTitle>
         <CardDescription>{totalStudents.toLocaleString()} total students</CardDescription>
-        <p className="text-xs text-muted-foreground leading-snug max-w-prose">
-          {getChartExportBlurb("risk-alert-distribution")}
-        </p>
-        <p className="text-xs text-muted-foreground">
-          <span className="font-medium text-foreground/90">Data source:</span>{" "}
-          student_level_with_predictions · at_risk_alert ·{" "}
-          <span className="font-medium text-foreground/90">Generated:</span>{" "}
-          {new Date().toLocaleDateString()}
-        </p>
+        <ChartExportGlossaryBlurb slug="risk-alert-distribution" />
+        <ChartExportDataSourceLine>
+          student_level_with_predictions · at_risk_alert ·
+        </ChartExportDataSourceLine>
         <CardAction>
           <div className="flex items-center gap-1">
             {info ? (
@@ -177,9 +171,7 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
           </PieChart>
         </ResponsiveContainer>
       </CardContent>
-      <CardFooter className="border-t border-border pt-6 text-xs text-muted-foreground">
-        {CHART_EXPORT_BRAND_LINE}
-      </CardFooter>
+      <ChartExportBrandFooter />
     </Card>
   )
 }

--- a/codebenders-dashboard/components/risk-alert-chart.tsx
+++ b/codebenders-dashboard/components/risk-alert-chart.tsx
@@ -1,8 +1,12 @@
 "use client"
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { useMemo, useRef } from "react"
+import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from "recharts"
 import { InfoPopover } from "@/components/info-popover"
+import { ChartExportMenu } from "@/components/chart-export-menu"
+import { getChartExportBlurb } from "@/lib/chart-export-glossary"
+import { CHART_EXPORT_BRAND_LINE } from "@/lib/chart-export-filename"
 
 interface RiskAlertData {
   category: string
@@ -43,7 +47,22 @@ const CustomLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent }: an
   )
 }
 
+const CHART_FILE_SLUG = "risk-alert-distribution" as const
+
 export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartProps) {
+  const exportRef = useRef<HTMLDivElement>(null)
+
+  const csvSpec = useMemo(
+    () =>
+      data?.length
+        ? {
+            headers: ["Alert Level", "Count", "Percentage"],
+            rows: data.map((d) => [d.category, d.count, `${Number(d.percentage).toFixed(1)}%`]),
+          }
+        : null,
+    [data]
+  )
+
   if (loading) {
     return (
       <Card>
@@ -88,16 +107,36 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
     percentage: item.percentage,
   }))
 
+  const totalStudents = data.reduce((sum, item) => sum + Number(item.count), 0)
+
   return (
-    <Card>
+    <Card ref={exportRef}>
       <CardHeader>
-        <div className="flex items-center">
-          <CardTitle>Risk Alert Distribution</CardTitle>
-          {info && <InfoPopover title="Risk Alert Distribution">{info}</InfoPopover>}
-        </div>
-        <CardDescription>
-          {data.reduce((sum, item) => sum + Number(item.count), 0).toLocaleString()} total students
-        </CardDescription>
+        <CardTitle>Risk Alert Distribution</CardTitle>
+        <CardDescription>{totalStudents.toLocaleString()} total students</CardDescription>
+        <p className="text-xs text-muted-foreground leading-snug max-w-prose">
+          {getChartExportBlurb("risk-alert-distribution")}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground/90">Data source:</span>{" "}
+          student_level_with_predictions · at_risk_alert ·{" "}
+          <span className="font-medium text-foreground/90">Generated:</span>{" "}
+          {new Date().toLocaleDateString()}
+        </p>
+        <CardAction>
+          <div className="flex items-center gap-1">
+            {info ? (
+              <span data-chart-export-exclude>
+                <InfoPopover title="Risk Alert Distribution">{info}</InfoPopover>
+              </span>
+            ) : null}
+            <ChartExportMenu
+              exportRef={exportRef}
+              chartFileSlug={CHART_FILE_SLUG}
+              csv={csvSpec}
+            />
+          </div>
+        </CardAction>
       </CardHeader>
       <CardContent>
         <ResponsiveContainer width="100%" height={300}>
@@ -130,7 +169,7 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
             <Legend 
               verticalAlign="bottom" 
               height={36}
-              formatter={(value, entry: any) => {
+              formatter={(value) => {
                 const item = data.find(d => d.category === value)
                 return `${value} (${item?.count.toLocaleString() || 0})`
               }}
@@ -138,6 +177,9 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
           </PieChart>
         </ResponsiveContainer>
       </CardContent>
+      <CardFooter className="border-t border-border pt-6 text-xs text-muted-foreground">
+        {CHART_EXPORT_BRAND_LINE}
+      </CardFooter>
     </Card>
   )
 }

--- a/codebenders-dashboard/lib/__tests__/metric-glossary-coverage.test.ts
+++ b/codebenders-dashboard/lib/__tests__/metric-glossary-coverage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { GLOSSARY_TOPIC_SECTIONS, METRIC_GLOSSARY_INDEX_SLUGS } from "@/lib/glossary-constants"
+import { CHART_EXPORT_GLOSSARY_PLAIN } from "@/lib/chart-export-glossary"
 import { parseGlossaryEntries, readMetricGlossaryMarkdown } from "@/lib/metric-glossary"
 
 describe("metric glossary coverage (#105 / #124)", () => {
@@ -15,5 +16,13 @@ describe("metric glossary coverage (#105 / #124)", () => {
   it("topic sections list each indexed slug exactly once in index order", () => {
     const listedSlugs = GLOSSARY_TOPIC_SECTIONS.flatMap((t) => [...t.slugOrder])
     expect(listedSlugs).toEqual([...METRIC_GLOSSARY_INDEX_SLUGS])
+  })
+
+  it("chart export blurbs cover every indexed glossary slug (#106)", () => {
+    for (const slug of METRIC_GLOSSARY_INDEX_SLUGS) {
+      const plain = CHART_EXPORT_GLOSSARY_PLAIN[slug]
+      expect(plain, `add Plain English to chart-export-glossary for ${slug}`).toBeTruthy()
+      expect(plain!.length).toBeGreaterThan(20)
+    }
   })
 })

--- a/codebenders-dashboard/lib/chart-export-capture.ts
+++ b/codebenders-dashboard/lib/chart-export-capture.ts
@@ -1,6 +1,18 @@
 import { toPng } from "html-to-image"
 import { jsPDF } from "jspdf"
 
+import { serializeChartExportCsv, type ChartExportCsvSpec } from "@/lib/chart-export-csv"
+
+export function triggerFileDownload(href: string, filename: string): void {
+  const a = document.createElement("a")
+  a.href = href
+  a.download = filename
+  a.rel = "noopener"
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+}
+
 export async function captureElementToPngDataUrl(node: HTMLElement): Promise<string> {
   if (typeof document !== "undefined" && document.fonts?.ready) {
     await document.fonts.ready
@@ -21,13 +33,17 @@ export async function captureElementToPngDataUrl(node: HTMLElement): Promise<str
 }
 
 export function downloadDataUrl(dataUrl: string, filename: string): void {
-  const a = document.createElement("a")
-  a.href = dataUrl
-  a.download = filename
-  a.rel = "noopener"
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
+  triggerFileDownload(dataUrl, filename)
+}
+
+export function downloadChartExportCsv(spec: ChartExportCsvSpec, filename: string): void {
+  const blob = new Blob([serializeChartExportCsv(spec)], { type: "text/csv;charset=utf-8" })
+  const url = URL.createObjectURL(blob)
+  try {
+    triggerFileDownload(url, filename)
+  } finally {
+    URL.revokeObjectURL(url)
+  }
 }
 
 export async function downloadChartPdf(node: HTMLElement, filename: string): Promise<void> {

--- a/codebenders-dashboard/lib/chart-export-capture.ts
+++ b/codebenders-dashboard/lib/chart-export-capture.ts
@@ -1,0 +1,53 @@
+import { toPng } from "html-to-image"
+import { jsPDF } from "jspdf"
+
+export async function captureElementToPngDataUrl(node: HTMLElement): Promise<string> {
+  if (typeof document !== "undefined" && document.fonts?.ready) {
+    await document.fonts.ready
+  }
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+  })
+
+  return toPng(node, {
+    pixelRatio: 2,
+    backgroundColor: "#ffffff",
+    cacheBust: true,
+    filter: (n) => {
+      if (!(n instanceof HTMLElement)) return true
+      return !n.hasAttribute("data-chart-export-exclude")
+    },
+  })
+}
+
+export function downloadDataUrl(dataUrl: string, filename: string): void {
+  const a = document.createElement("a")
+  a.href = dataUrl
+  a.download = filename
+  a.rel = "noopener"
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+}
+
+export async function downloadChartPdf(node: HTMLElement, filename: string): Promise<void> {
+  const dataUrl = await captureElementToPngDataUrl(node)
+  const img = new Image()
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => resolve()
+    img.onerror = () => reject(new Error("Chart export: failed to load PNG for PDF"))
+    img.src = dataUrl
+  })
+
+  const w = img.naturalWidth
+  const h = img.naturalHeight
+  const orientation = w >= h ? "landscape" : "portrait"
+  const pdf = new jsPDF({
+    orientation,
+    unit: "px",
+    format: [w, h],
+    hotfixes: ["px_scaling"],
+  })
+  pdf.addImage(dataUrl, "PNG", 0, 0, w, h, undefined, "FAST")
+  pdf.save(filename)
+}

--- a/codebenders-dashboard/lib/chart-export-csv.ts
+++ b/codebenders-dashboard/lib/chart-export-csv.ts
@@ -1,0 +1,30 @@
+export interface ChartExportCsvSpec {
+  headers: string[]
+  rows: (string | number)[][]
+}
+
+function escapeCsvCell(v: string | number): string {
+  const s = String(v)
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`
+  return s
+}
+
+export function serializeChartExportCsv(spec: ChartExportCsvSpec): string {
+  const lines = [
+    spec.headers.map(escapeCsvCell).join(","),
+    ...spec.rows.map((row) => row.map(escapeCsvCell).join(",")),
+  ]
+  return lines.join("\n")
+}
+
+/** CSV for charts with category, count, and percentage columns. */
+export function buildCategoryCountPercentageCsv(
+  data: { category: string; count: number; percentage: number }[] | null | undefined,
+  columnHeaders: readonly [string, string, string]
+): ChartExportCsvSpec | null {
+  if (!data?.length) return null
+  return {
+    headers: [...columnHeaders],
+    rows: data.map((d) => [d.category, d.count, `${Number(d.percentage).toFixed(1)}%`]),
+  }
+}

--- a/codebenders-dashboard/lib/chart-export-filename.ts
+++ b/codebenders-dashboard/lib/chart-export-filename.ts
@@ -1,0 +1,18 @@
+/** Institution segment for export filenames (issue #106: <institution>_<chart>_<date>.ext). */
+export const CHART_EXPORT_INSTITUTION_SLUG = "bishop-state-community-college" as const
+
+export const CHART_EXPORT_INSTITUTION_NAME = "Bishop State Community College" as const
+
+export const CHART_EXPORT_BRAND_LINE = `${CHART_EXPORT_INSTITUTION_NAME} · Student Success Dashboard` as const
+
+export function chartExportDateStamp(d = new Date()): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+
+export function buildChartExportBasename(chartFileSlug: string, d = new Date()): string {
+  const safe = chartFileSlug.replace(/[^a-z0-9-]+/gi, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").toLowerCase()
+  return `${CHART_EXPORT_INSTITUTION_SLUG}_${safe}_${chartExportDateStamp(d)}`
+}

--- a/codebenders-dashboard/lib/chart-export-glossary.ts
+++ b/codebenders-dashboard/lib/chart-export-glossary.ts
@@ -1,0 +1,31 @@
+import type { MetricGlossarySlug } from "@/lib/glossary-constants"
+
+/**
+ * Plain-English lines from `content/metric-glossary.md` (## sections).
+ * Keep in sync when glossary changes; used for chart PNG/PDF captions.
+ */
+export const CHART_EXPORT_GLOSSARY_PLAIN: Record<MetricGlossarySlug, string> = {
+  "overall-retention-rate":
+    'Share of students in the selected cohort who are still enrolled (or completed) one year later — a common "year-to-year" retention view for the students you are filtering.',
+  "avg-predicted-retention":
+    "Average of the model's estimated probability (0-100%) that each student in the filtered set will retain — not the same as historical retention above.",
+  "students-at-high-critical-risk":
+    "Count of students whose composite risk score places them in the HIGH or URGENT alert bands used for intervention triage.",
+  "avg-course-completion":
+    "Credits successfully completed divided by credits attempted, expressed as a percentage, aggregated across students in the filter.",
+  "risk-alert-distribution":
+    "Pie chart of students grouped by composite risk alert band (LOW, MODERATE, HIGH, URGENT) used for triage — not the same as the retention-probability-only funnel chart.",
+  "retention-risk-funnel":
+    "Horizontal bar chart of students by model retention risk category (Critical / High / Moderate / Low) from predicted retention probability alone.",
+  "readiness-assessment":
+    "PDP-aligned readiness index — composite score and High / Medium / Low bands summarizing academic, engagement, and ML-risk components for the filtered cohort.",
+}
+
+const SENTENCE_END = /(?<=[.!?])\s+/
+
+/** Up to two sentences for slide-friendly captions. */
+export function getChartExportBlurb(slug: MetricGlossarySlug): string {
+  const text = CHART_EXPORT_GLOSSARY_PLAIN[slug]
+  const parts = text.split(SENTENCE_END).filter(Boolean)
+  return parts.slice(0, 2).join(" ")
+}

--- a/codebenders-dashboard/package.json
+++ b/codebenders-dashboard/package.json
@@ -20,6 +20,8 @@
     "ai": "^5.0.81",
     "class-variance-authority": "^0.7.1",
     "clsx": "2.1.1",
+    "html-to-image": "^1.11.13",
+    "jspdf": "^4.2.1",
     "lucide-react": "0.548.0",
     "next": "^16.1.6",
     "papaparse": "^5.5.3",
@@ -34,7 +36,6 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "yaml": "^2.8.0",
     "@types/node": "24.9.2",
     "@types/papaparse": "^5.5.2",
     "@types/pg": "^8.16.0",
@@ -46,6 +47,7 @@
     "tailwindcss": "4.1.16",
     "tsx": "^4.21.0",
     "typescript": "5.9.3",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "yaml": "^2.8.0"
   }
 }


### PR DESCRIPTION
## Summary
Closes #106 (or link when issue exists).

Adds a per-chart **Export** menu on the home dashboard Recharts and readiness distribution cards: **CSV**, **PNG**, and **PDF**. Exports include title, glossary Plain English blurb (1–2 sentences), data source + generated date, and Bishop State branding footer.

## Implementation notes
- Client-side capture: `html-to-image` → PNG; `jspdf` embeds PNG for PDF.
- Filenames: `bishop-state-community-college_<chart-slug>_YYYY-MM-DD.{csv,png,pdf}`.
- Glossary text is aligned with `content/metric-glossary.md` via `lib/chart-export-glossary.ts`; coverage test extended in `metric-glossary-coverage.test.ts`.
- Shared helpers: `chart-export-csv.ts`, `chart-export-card-meta.tsx`, `chart-export-capture.ts`.

## Charts covered
- Risk Alert Distribution, Retention Risk Funnel
- Readiness Level Distribution, Score Distribution

## Out of scope (per issue)
- PPTX / bulk deck; courses page charts unchanged.

## Verify
- `cd codebenders-dashboard && npm run test && npm run build`

Made with [Cursor](https://cursor.com)