### PR TITLE
feat: data lineage view (#107)

### DIFF
--- a/codebenders-dashboard/app/api/lineage/route.ts
+++ b/codebenders-dashboard/app/api/lineage/route.ts
@@ -1,0 +1,250 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { getPool } from "@/lib/db"
+import { canAccess, type Role } from "@/lib/roles"
+import {
+  buildStudentLevelDashboardConditionsAliased,
+  optionalDashboardFilterRecord,
+  type DashboardFilterParams,
+} from "@/lib/dashboard-filters"
+import {
+  LINEAGE_STUDENT_LEVEL_SCHEMA_IDS,
+  isLineageMetricId,
+  lineageStepsForMetric,
+  isRosterLineageField,
+  rosterFieldLineageLabel,
+  type LineageMetricId,
+} from "@/lib/lineage-config"
+import { SCHEMAS } from "@/lib/upload-schemas"
+
+const MAX_PAGE_SIZE = 100
+
+type LineageUploadHistoryRow = {
+  id: string
+  filename: string
+  file_type: string
+  uploaded_at: Date
+  status: string
+  user_email: string | null
+  rows_inserted: number
+  rows_skipped: number
+  error_count: number
+  has_validation_report: boolean
+}
+
+const METRIC_LABEL: Record<LineageMetricId, string> = {
+  overall_retention: "Overall retention rate",
+  avg_predicted_retention: "Average predicted retention",
+  high_critical_risk_count: "Students at high / critical risk",
+  avg_course_completion: "Average course completion",
+  risk_alert_segment: "Risk alert segment",
+  retention_risk_segment: "Retention risk segment",
+  roster_cell: "Roster value",
+}
+
+function metricDescription(metric: LineageMetricId, category: string | null): string {
+  switch (metric) {
+    case "risk_alert_segment":
+      return category
+        ? `Students in the “${category}” slice of the risk alert distribution.`
+        : "A slice of the risk alert distribution."
+    case "retention_risk_segment":
+      return category
+        ? `Students in the “${category}” retention-probability band.`
+        : "A slice of the retention risk distribution."
+    case "roster_cell":
+      return "Single student field as shown on the roster."
+    default:
+      return METRIC_LABEL[metric]
+  }
+}
+
+function appendMetricPredicate(
+  metric: LineageMetricId,
+  category: string | null,
+  studentGuid: string | null,
+  conditions: string[],
+  values: unknown[]
+): { error?: string } {
+  switch (metric) {
+    case "high_critical_risk_count":
+      conditions.push(`s.at_risk_alert IN ('HIGH', 'URGENT')`)
+      return {}
+    case "risk_alert_segment":
+      if (!category?.trim()) return { error: "category is required for risk_alert_segment" }
+      values.push(category.trim())
+      conditions.push(`s.at_risk_alert = $${values.length}`)
+      return {}
+    case "retention_risk_segment":
+      if (!category?.trim()) return { error: "category is required for retention_risk_segment" }
+      values.push(category.trim())
+      conditions.push(`s.retention_risk_category = $${values.length}`)
+      return {}
+    case "roster_cell":
+      if (!studentGuid?.trim()) return { error: "studentGuid is required for roster_cell" }
+      values.push(studentGuid.trim())
+      conditions.push(`s."Student_GUID" = $${values.length}`)
+      return {}
+    default:
+      return {}
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const role = request.headers.get("x-user-role") as Role | null
+  if (!role) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const metricRaw = searchParams.get("metric") || ""
+  if (!isLineageMetricId(metricRaw)) {
+    return NextResponse.json(
+      { error: "Invalid or missing metric", allowed: "overall_retention | avg_predicted_retention | …" },
+      { status: 400 }
+    )
+  }
+  const metric = metricRaw
+
+  const cohort = searchParams.get("cohort") ?? ""
+  const enrollmentType = searchParams.get("enrollmentType") ?? ""
+  const credentialType = searchParams.get("credentialType") ?? ""
+  const category = searchParams.get("category") ?? ""
+  const studentGuid = searchParams.get("studentGuid") ?? ""
+  const fieldRaw = searchParams.get("field") ?? ""
+  const categoryForApi = category || null
+
+  if (metric === "roster_cell") {
+    if (!isRosterLineageField(fieldRaw)) {
+      return NextResponse.json({ error: "Invalid or missing field for roster_cell" }, { status: 400 })
+    }
+  }
+
+  const page = Math.max(1, Number(searchParams.get("page") || 1))
+  const pageSize = Math.min(MAX_PAGE_SIZE, Math.max(1, Number(searchParams.get("pageSize") || 50)))
+  const offset = (page - 1) * pageSize
+
+  const showIdentifiers = canAccess("/api/students", role)
+
+  const filterParams: DashboardFilterParams = { cohort, enrollmentType, credentialType }
+  const { conditions: filterConds, values: filterVals } =
+    metric === "roster_cell"
+      ? { conditions: [] as string[], values: [] as unknown[] }
+      : buildStudentLevelDashboardConditionsAliased(filterParams, "s")
+
+  const conditions = [...filterConds]
+  const values = [...filterVals]
+
+  const predErr = appendMetricPredicate(metric, categoryForApi, studentGuid || null, conditions, values)
+  if (predErr.error) {
+    return NextResponse.json({ error: predErr.error }, { status: 400 })
+  }
+
+  const whereSql = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
+
+  const pool = getPool()
+
+  try {
+    const [countRes, uploadRes] = await Promise.all([
+      pool.query<{ c: number }>(
+        `SELECT COUNT(*)::int AS c FROM student_level_with_predictions s ${whereSql}`,
+        values
+      ),
+      pool.query<LineageUploadHistoryRow>(
+        `SELECT id, filename, file_type, uploaded_at, status, user_email, rows_inserted, rows_skipped, error_count,
+                (validation_report IS NOT NULL) AS has_validation_report
+         FROM upload_history
+         WHERE file_type = ANY($1::text[])
+         ORDER BY uploaded_at DESC
+         LIMIT 1`,
+        [LINEAGE_STUDENT_LEVEL_SCHEMA_IDS]
+      ),
+    ])
+
+    const rowCount = Number(countRes.rows[0]?.c ?? 0)
+    const uploadRow = uploadRes.rows[0]
+
+    const schemaMeta = uploadRow ? SCHEMAS.find((x) => x.id === uploadRow.file_type) : undefined
+
+    let sourceRows: Record<string, unknown>[] | undefined
+    if (showIdentifiers && rowCount > 0) {
+      const dataSql = `
+        SELECT
+          s."Student_GUID" AS student_guid,
+          s."Cohort" AS cohort,
+          s."Enrollment_Intensity_First_Term" AS enrollment_intensity,
+          s."Retention" AS retention,
+          ROUND((s.retention_probability * 100)::numeric, 1) AS retention_pct,
+          s.at_risk_alert,
+          s.retention_risk_category,
+          ROUND((s.course_completion_rate * 100)::numeric, 1) AS course_completion_pct
+        FROM student_level_with_predictions s
+        ${whereSql}
+        ORDER BY s."Student_GUID"
+        LIMIT $${values.length + 1} OFFSET $${values.length + 2}
+      `
+      const dataRes = await pool.query(dataSql, [...values, pageSize, offset])
+      sourceRows = dataRes.rows as Record<string, unknown>[]
+    }
+
+    const steps = lineageStepsForMetric(metric)
+    if (metric === "roster_cell" && isRosterLineageField(fieldRaw)) {
+      const rf = rosterFieldLineageLabel(fieldRaw)
+      steps.push({
+        order: 4,
+        title: rf.label,
+        detail: rf.detail,
+      })
+    }
+
+    const uploadEvent = uploadRow
+      ? {
+          id: Number(uploadRow.id),
+          filename: uploadRow.filename,
+          fileType: uploadRow.file_type,
+          schemaLabel: schemaMeta?.label ?? uploadRow.file_type,
+          uploadedAt: uploadRow.uploaded_at.toISOString(),
+          status: uploadRow.status,
+          userEmail: uploadRow.user_email,
+          rowsInserted: Number(uploadRow.rows_inserted ?? 0),
+          rowsSkipped: Number(uploadRow.rows_skipped ?? 0),
+          errorCount: Number(uploadRow.error_count ?? 0),
+          hasValidationReport: Boolean(uploadRow.has_validation_report),
+        }
+      : null
+
+    return NextResponse.json({
+      metricId: metric,
+      metricLabel: METRIC_LABEL[metric],
+      metricDescription: metricDescription(metric, categoryForApi),
+      field: metric === "roster_cell" ? fieldRaw : undefined,
+      filters: metric === "roster_cell" ? {} : optionalDashboardFilterRecord(filterParams),
+      dimension: category || undefined,
+      aggregate: {
+        rowCount,
+        summary:
+          metric === "roster_cell"
+            ? "One student row."
+            : `${rowCount.toLocaleString()} student(s) match the current filters and metric scope.`,
+      },
+      sourceRowsVisible: showIdentifiers,
+      sourceRowsRestrictedMessage: showIdentifiers
+        ? undefined
+        : "Row-level identifiers are available to Admin, Advisor, and IR roles (same access as the student roster).",
+      sourceRows:
+        showIdentifiers && sourceRows
+          ? { page, pageSize, total: rowCount, rows: sourceRows }
+          : undefined,
+      uploadEvent,
+      transformationSteps: steps,
+    })
+  } catch (error) {
+    console.error("Lineage API error:", error)
+    return NextResponse.json(
+      {
+        error: "Failed to load lineage",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/codebenders-dashboard/app/page.tsx
+++ b/codebenders-dashboard/app/page.tsx
@@ -17,6 +17,9 @@ import {
 import { TrendingUp, Users, AlertTriangle, BookOpen, Search, Table2, X } from "lucide-react"
 import Link from "next/link"
 import { GlossaryMetricEntryLink } from "@/components/glossary-metric-entry-link"
+import { useDataLineage } from "@/components/data-lineage-drawer"
+import { optionalDashboardFilterRecord } from "@/lib/dashboard-filters"
+import type { LineageMetricId } from "@/lib/lineage-config"
 
 interface KPIData {
   overallRetentionRate: string
@@ -60,6 +63,7 @@ const ENROLLMENT_TYPES = ["Full-Time", "Part-Time"]
 const CREDENTIAL_TYPES = ["Certificate", "Associate", "Bachelor"]
 
 export default function DashboardPage() {
+  const { drawer: lineageDrawer, openLineage } = useDataLineage()
   const [kpis, setKpis] = useState<KPIData | null>(null)
   const [riskAlerts, setRiskAlerts] = useState<RiskAlertData[]>([])
   const [retentionRisk, setRetentionRisk] = useState<RetentionRiskData[]>([])
@@ -83,6 +87,13 @@ export default function DashboardPage() {
     if (credentialType) p.set("credentialType", credentialType)
     const qs = p.toString()
     return qs ? `?${qs}` : ""
+  }
+
+  function openKpiLineage(metric: LineageMetricId) {
+    openLineage({
+      metric,
+      ...optionalDashboardFilterRecord({ cohort, enrollmentType, credentialType }),
+    })
   }
 
   useEffect(() => {
@@ -271,6 +282,7 @@ export default function DashboardPage() {
             icon={TrendingUp}
             subtitle={kpis ? `${kpis.totalStudents.toLocaleString()} total students` : undefined}
             loading={loading}
+            onLineageClick={loading ? undefined : () => openKpiLineage("overall_retention")}
             info={
               <>
                 <p><strong>What it shows:</strong> Percentage of students retained year-to-year based on historical data.</p>
@@ -286,6 +298,7 @@ export default function DashboardPage() {
             icon={Users}
             subtitle="ML model prediction"
             loading={loading}
+            onLineageClick={loading ? undefined : () => openKpiLineage("avg_predicted_retention")}
             info={
               <>
                 <p><strong>Model:</strong> XGBoost Classifier trained on 31 features including demographics, academic prep, and course performance.</p>
@@ -307,6 +320,7 @@ export default function DashboardPage() {
             icon={AlertTriangle}
             subtitle="Require immediate intervention"
             loading={loading}
+            onLineageClick={loading ? undefined : () => openKpiLineage("high_critical_risk_count")}
             info={
               <>
                 <p><strong>How it's calculated:</strong> Composite risk score combining:</p>
@@ -332,6 +346,7 @@ export default function DashboardPage() {
             icon={BookOpen}
             subtitle="Credits earned / attempted"
             loading={loading}
+            onLineageClick={loading ? undefined : () => openKpiLineage("avg_course_completion")}
             info={
               <>
                 <p><strong>Formula:</strong> (Total credits earned ÷ Total credits attempted) × 100</p>
@@ -354,6 +369,13 @@ export default function DashboardPage() {
           <RiskAlertChart
             data={riskAlerts}
             loading={loading}
+            onSegmentLineage={(category) =>
+              openLineage({
+                metric: "risk_alert_segment",
+                category,
+                ...optionalDashboardFilterRecord({ cohort, enrollmentType, credentialType }),
+              })
+            }
             info={
               <>
                 <p><strong>What it shows:</strong> Distribution of students across risk alert levels (URGENT, HIGH, MODERATE, LOW).</p>
@@ -427,6 +449,7 @@ export default function DashboardPage() {
           </div>
         </div>
       </div>
+      {lineageDrawer}
     </div>
   )
 }

--- a/codebenders-dashboard/app/students/page.tsx
+++ b/codebenders-dashboard/app/students/page.tsx
@@ -6,8 +6,9 @@ import { useRouter } from "next/navigation"
 import { ArrowLeft, ArrowUpDown, ArrowUp, ArrowDown, Download, Search, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Badge } from "@/components/ui/badge"
 import { InfoPopover } from "@/components/info-popover"
+import { useDataLineage, type LineageOpenRequest } from "@/components/data-lineage-drawer"
+import type { RosterLineageField } from "@/lib/lineage-config"
 import {
   Select,
   SelectContent,
@@ -61,6 +62,10 @@ const ENROLLMENT_TYPES = [
   { value: "Full-Time",  label: "Full-time" },
   { value: "Part-Time",  label: "Part-time" },
 ] as const
+
+function rosterCellLineage(studentGuid: string, field: RosterLineageField): LineageOpenRequest {
+  return { metric: "roster_cell", studentGuid, field }
+}
 
 // ─── Badge helpers ────────────────────────────────────────────────────────────
 
@@ -120,6 +125,7 @@ function SortIcon({ active, dir }: { active: boolean; dir: "asc" | "desc" }) {
 
 export default function StudentsPage() {
   const router = useRouter()
+  const { drawer: lineageDrawer, openLineage } = useDataLineage()
   const [data, setData]           = useState<StudentsResponse | null>(null)
   const [loading, setLoading]     = useState(true)
   const [error, setError]         = useState<string | null>(null)
@@ -500,31 +506,86 @@ export default function StudentsPage() {
                         {s.student_guid ? s.student_guid.slice(0, 12) + "…" : "—"}
                       </Link>
                     </td>
-                    <td className="px-3 py-2.5 text-xs">{s.cohort ?? "—"}</td>
-                    <td className="px-3 py-2.5 text-xs whitespace-nowrap">
-                      {s.enrollment_intensity === "Full-Time" || s.enrollment_intensity === "Full Time" || s.enrollment_intensity === "FT"
-                        ? "Full-time"
-                        : s.enrollment_intensity === "Part-Time" || s.enrollment_intensity === "Part Time" || s.enrollment_intensity === "PT"
-                        ? "Part-time"
-                        : s.enrollment_intensity ?? "—"}
+                    <td className="px-3 py-2.5 text-xs" onClick={(e) => e.stopPropagation()}>
+                      <LineageValueButton
+                        onLineage={() => openLineage(rosterCellLineage(s.student_guid, "cohort"))}
+                      >
+                        {s.cohort ?? "—"}
+                      </LineageValueButton>
                     </td>
-                    <td className="px-3 py-2.5"><AlertBadge level={s.at_risk_alert} /></td>
-                    <td className="px-3 py-2.5"><Pct value={s.retention_pct} /></td>
-                    <td className="px-3 py-2.5">
+                    <td className="px-3 py-2.5 text-xs whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
+                      <LineageValueButton
+                        onLineage={() => openLineage(rosterCellLineage(s.student_guid, "enrollment_intensity"))}
+                      >
+                        {s.enrollment_intensity === "Full-Time" || s.enrollment_intensity === "Full Time" || s.enrollment_intensity === "FT"
+                          ? "Full-time"
+                          : s.enrollment_intensity === "Part-Time" || s.enrollment_intensity === "Part Time" || s.enrollment_intensity === "PT"
+                          ? "Part-time"
+                          : s.enrollment_intensity ?? "—"}
+                      </LineageValueButton>
+                    </td>
+                    <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
+                      <LineageValueButton
+                        className="inline-flex"
+                        onLineage={() => openLineage(rosterCellLineage(s.student_guid, "at_risk_alert"))}
+                      >
+                        <AlertBadge level={s.at_risk_alert} />
+                      </LineageValueButton>
+                    </td>
+                    <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
+                      <LineageValueButton
+                        onLineage={() => openLineage(rosterCellLineage(s.student_guid, "retention_pct"))}
+                      >
+                        <Pct value={s.retention_pct} />
+                      </LineageValueButton>
+                    </td>
+                    <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
                       <div className="flex items-center gap-1.5">
                         {s.readiness_pct !== null && (
-                          <span className="text-sm font-medium">{s.readiness_pct}%</span>
+                          <LineageValueButton
+                            onLineage={() => openLineage(rosterCellLineage(s.student_guid, "readiness_pct"))}
+                          >
+                            <span className="text-sm font-medium">{s.readiness_pct}%</span>
+                          </LineageValueButton>
                         )}
                         <ReadinessBadge level={s.readiness_level} />
                       </div>
                     </td>
-                    <td className="px-3 py-2.5"><Pct value={s.gateway_math_pct} /></td>
-                    <td className="px-3 py-2.5"><Pct value={s.gateway_english_pct} /></td>
-                    <td className="px-3 py-2.5"><Pct value={s.gpa_risk_pct} invert /></td>
-                    <td className="px-3 py-2.5 text-xs">
-                      {s.time_to_credential ? `${s.time_to_credential} yr` : "—"}
+                    <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
+                      <LineageValueButton
+                        onLineage={() => openLineage(rosterCellLineage(s.student_guid, "gateway_math_pct"))}
+                      >
+                        <Pct value={s.gateway_math_pct} />
+                      </LineageValueButton>
                     </td>
-                    <td className="px-3 py-2.5 text-xs">{s.credential_type ?? "—"}</td>
+                    <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
+                      <LineageValueButton
+                        onLineage={() => openLineage(rosterCellLineage(s.student_guid, "gateway_english_pct"))}
+                      >
+                        <Pct value={s.gateway_english_pct} />
+                      </LineageValueButton>
+                    </td>
+                    <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
+                      <LineageValueButton
+                        onLineage={() => openLineage(rosterCellLineage(s.student_guid, "gpa_risk_pct"))}
+                      >
+                        <Pct value={s.gpa_risk_pct} invert />
+                      </LineageValueButton>
+                    </td>
+                    <td className="px-3 py-2.5 text-xs" onClick={(e) => e.stopPropagation()}>
+                      <LineageValueButton
+                        onLineage={() => openLineage(rosterCellLineage(s.student_guid, "time_to_credential"))}
+                      >
+                        {s.time_to_credential ? `${s.time_to_credential} yr` : "—"}
+                      </LineageValueButton>
+                    </td>
+                    <td className="px-3 py-2.5 text-xs" onClick={(e) => e.stopPropagation()}>
+                      <LineageValueButton
+                        onLineage={() => openLineage(rosterCellLineage(s.student_guid, "credential_type"))}
+                      >
+                        {s.credential_type ?? "—"}
+                      </LineageValueButton>
+                    </td>
                   </tr>
                 ))
               )}
@@ -545,7 +606,32 @@ export default function StudentsPage() {
           </div>
         )}
       </div>
+      {lineageDrawer}
     </div>
+  )
+}
+
+function LineageValueButton({
+  children,
+  onLineage,
+  className = "",
+}: {
+  children: React.ReactNode
+  onLineage: () => void
+  className?: string
+}) {
+  return (
+    <button
+      type="button"
+      title="View data lineage for this value"
+      className={`max-w-full text-left rounded-sm hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${className}`}
+      onClick={(e) => {
+        e.stopPropagation()
+        onLineage()
+      }}
+    >
+      {children}
+    </button>
   )
 }
 

--- a/codebenders-dashboard/components/data-lineage-drawer.tsx
+++ b/codebenders-dashboard/components/data-lineage-drawer.tsx
@@ -1,0 +1,310 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import type { LineageMetricId } from "@/lib/lineage-config"
+import type { LineageApiResponse } from "@/lib/lineage-types"
+import { GitBranch, Loader2 } from "lucide-react"
+
+export type LineageOpenRequest = {
+  metric: LineageMetricId
+  cohort?: string
+  enrollmentType?: string
+  credentialType?: string
+  category?: string
+  studentGuid?: string
+  field?: string
+}
+
+function buildLineageUrl(req: LineageOpenRequest, page: number, pageSize: number) {
+  const p = new URLSearchParams()
+  p.set("metric", req.metric)
+  p.set("page", String(page))
+  p.set("pageSize", String(pageSize))
+  if (req.cohort) p.set("cohort", req.cohort)
+  if (req.enrollmentType) p.set("enrollmentType", req.enrollmentType)
+  if (req.credentialType) p.set("credentialType", req.credentialType)
+  if (req.category) p.set("category", req.category)
+  if (req.studentGuid) p.set("studentGuid", req.studentGuid)
+  if (req.field) p.set("field", req.field)
+  return `/api/lineage?${p.toString()}`
+}
+
+export function useDataLineage() {
+  const [open, setOpen] = useState(false)
+  const [request, setRequest] = useState<LineageOpenRequest | null>(null)
+  const [page, setPage] = useState(1)
+
+  const openLineage = useCallback((r: LineageOpenRequest) => {
+    setRequest(r)
+    setPage(1)
+    setOpen(true)
+  }, [])
+
+  const drawer = (
+    <DataLineageDrawer
+      open={open}
+      page={page}
+      onPageChange={setPage}
+      onOpenChange={(v) => {
+        setOpen(v)
+        if (!v) {
+          setRequest(null)
+          setPage(1)
+        }
+      }}
+      request={request}
+    />
+  )
+
+  return { drawer, openLineage }
+}
+
+type DataLineageDrawerProps = {
+  open: boolean
+  page: number
+  onPageChange: (page: number) => void
+  onOpenChange: (open: boolean) => void
+  request: LineageOpenRequest | null
+}
+
+export function DataLineageDrawer({ open, page, onPageChange, onOpenChange, request }: DataLineageDrawerProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [data, setData] = useState<LineageApiResponse | null>(null)
+
+  useEffect(() => {
+    if (!open || !request) {
+      return
+    }
+
+    let cancelled = false
+    const run = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch(buildLineageUrl(request, page, 50))
+        const json = await res.json()
+        if (!res.ok) {
+          throw new Error(json.error || "Failed to load lineage")
+        }
+        if (!cancelled) {
+          setData(json as LineageApiResponse)
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setData(null)
+          setError(e instanceof Error ? e.message : "Failed to load lineage")
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void run()
+    return () => {
+      cancelled = true
+    }
+  }, [open, request, page])
+
+  const totalPages =
+    data?.sourceRows?.total != null && data.sourceRows.pageSize > 0
+      ? Math.max(1, Math.ceil(data.sourceRows.total / data.sourceRows.pageSize))
+      : 1
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 pr-8">
+            <GitBranch className="h-5 w-5 shrink-0 text-muted-foreground" />
+            Data lineage
+          </DialogTitle>
+          <DialogDescription asChild>
+            <div className="text-left space-y-1 pt-1">
+              {data ? (
+                <>
+                  <p className="text-sm text-foreground font-medium">{data.metricLabel}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Upload event, source rows, and transformation chain for this aggregate.
+                  </p>
+                </>
+              ) : request ? (
+                <p className="text-xs text-muted-foreground">Loading metric details…</p>
+              ) : null}
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground py-6">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading lineage…
+          </div>
+        )}
+
+        {error && (
+          <div className="text-sm text-destructive border border-destructive/30 rounded-md p-3">{error}</div>
+        )}
+
+        {!loading && data && (
+          <div className="space-y-6 text-sm">
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Metric
+              </h3>
+              <p className="font-medium text-foreground">{data.metricLabel}</p>
+              <p className="text-muted-foreground mt-1">{data.metricDescription}</p>
+              {data.field ? (
+                <p className="text-xs text-muted-foreground mt-2">
+                  Column: <span className="font-mono">{data.field}</span>
+                </p>
+              ) : null}
+              <p className="text-xs text-muted-foreground mt-2">{data.aggregate.summary}</p>
+            </section>
+
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Latest ingest event
+              </h3>
+              {data.uploadEvent ? (
+                <ul className="space-y-1 text-muted-foreground">
+                  <li>
+                    <span className="text-foreground font-medium">File:</span> {data.uploadEvent.filename}
+                  </li>
+                  <li>
+                    <span className="text-foreground font-medium">Schema:</span> {data.uploadEvent.schemaLabel}{" "}
+                    <span className="font-mono text-xs">({data.uploadEvent.fileType})</span>
+                  </li>
+                  <li>
+                    <span className="text-foreground font-medium">Uploaded:</span>{" "}
+                    {new Date(data.uploadEvent.uploadedAt).toLocaleString()}
+                  </li>
+                  <li>
+                    <span className="text-foreground font-medium">Status:</span> {data.uploadEvent.status} · rows
+                    inserted {data.uploadEvent.rowsInserted.toLocaleString()}
+                    {data.uploadEvent.hasValidationReport ? " · validation report stored" : ""}
+                  </li>
+                  {data.uploadEvent.userEmail ? (
+                    <li>
+                      <span className="text-foreground font-medium">By:</span> {data.uploadEvent.userEmail}
+                    </li>
+                  ) : null}
+                </ul>
+              ) : (
+                <p className="text-muted-foreground">No upload history found for student-level schemas yet.</p>
+              )}
+            </section>
+
+            <section>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Transformation chain
+              </h3>
+              <ol className="list-decimal pl-4 space-y-3 text-muted-foreground">
+                {data.transformationSteps
+                  .slice()
+                  .sort((a, b) => a.order - b.order)
+                  .map((step) => (
+                    <li key={step.order}>
+                      <span className="text-foreground font-medium">{step.title}</span>
+                      <p className="mt-0.5 text-xs leading-relaxed">{step.detail}</p>
+                    </li>
+                  ))}
+              </ol>
+            </section>
+
+            {data.sourceRowsRestrictedMessage ? (
+              <section>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  Source rows
+                </h3>
+                <p className="text-muted-foreground text-xs leading-relaxed">{data.sourceRowsRestrictedMessage}</p>
+              </section>
+            ) : null}
+
+            {data.sourceRows && data.sourceRows.rows.length > 0 ? (
+              <section>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  Source rows (paginated)
+                </h3>
+                <p className="text-xs text-muted-foreground mb-2">
+                  Showing {data.sourceRows.rows.length} of {data.sourceRows.total.toLocaleString()} · page{" "}
+                  {data.sourceRows.page} of {totalPages}
+                </p>
+                <div className="border rounded-md overflow-x-auto max-h-56 overflow-y-auto">
+                  <table className="w-full text-xs">
+                    <thead className="bg-muted/50 sticky top-0">
+                      <tr className="border-b">
+                        <th className="text-left p-2 font-semibold">Student GUID</th>
+                        <th className="text-left p-2 font-semibold">Cohort</th>
+                        <th className="text-left p-2 font-semibold">Retention %</th>
+                        <th className="text-left p-2 font-semibold">Alert</th>
+                        <th className="text-left p-2 font-semibold">Risk band</th>
+                        <th className="text-left p-2 font-semibold">Course compl. %</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.sourceRows.rows.map((row, i) => (
+                        <tr key={i} className="border-b border-border/60">
+                          <td className="p-2 font-mono whitespace-nowrap">
+                            {String(row.student_guid ?? "").slice(0, 14)}…
+                          </td>
+                          <td className="p-2">{String(row.cohort ?? "—")}</td>
+                          <td className="p-2">{row.retention_pct != null ? String(row.retention_pct) : "—"}</td>
+                          <td className="p-2">{String(row.at_risk_alert ?? "—")}</td>
+                          <td className="p-2">{String(row.retention_risk_category ?? "—")}</td>
+                          <td className="p-2">
+                            {row.course_completion_pct != null ? String(row.course_completion_pct) : "—"}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                {totalPages > 1 ? (
+                  <div className="flex items-center justify-end gap-2 mt-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={page <= 1}
+                      onClick={() => onPageChange(page - 1)}
+                    >
+                      Previous
+                    </Button>
+                    <span className="text-xs text-muted-foreground">
+                      Page {page} / {totalPages}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={page >= totalPages}
+                      onClick={() => onPageChange(page + 1)}
+                    >
+                      Next
+                    </Button>
+                  </div>
+                ) : null}
+              </section>
+            ) : null}
+
+            {!data.sourceRowsRestrictedMessage &&
+            data.sourceRowsVisible &&
+            data.aggregate.rowCount > 0 &&
+            (!data.sourceRows || data.sourceRows.rows.length === 0) ? (
+              <p className="text-xs text-muted-foreground">No rows returned for this page.</p>
+            ) : null}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/codebenders-dashboard/components/kpi-card.tsx
+++ b/codebenders-dashboard/components/kpi-card.tsx
@@ -13,9 +13,20 @@ interface KPICardProps {
   }
   loading?: boolean
   info?: React.ReactNode
+  /** Opens data lineage drawer (issue #107). */
+  onLineageClick?: () => void
 }
 
-export function KPICard({ title, value, icon: Icon, subtitle, trend, loading = false, info }: KPICardProps) {
+export function KPICard({
+  title,
+  value,
+  icon: Icon,
+  subtitle,
+  trend,
+  loading = false,
+  info,
+  onLineageClick,
+}: KPICardProps) {
   if (loading) {
     return (
       <Card>
@@ -46,7 +57,18 @@ export function KPICard({ title, value, icon: Icon, subtitle, trend, loading = f
         {Icon && <Icon className="h-4 w-4 text-muted-foreground" />}
       </CardHeader>
       <CardContent>
-        <div className="text-2xl font-bold">{value}</div>
+        {onLineageClick ? (
+          <button
+            type="button"
+            onClick={onLineageClick}
+            className="text-left rounded-md -m-1 p-1 w-full min-w-0 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
+            title="View data lineage for this KPI"
+          >
+            <div className="text-2xl font-bold">{value}</div>
+          </button>
+        ) : (
+          <div className="text-2xl font-bold">{value}</div>
+        )}
         {subtitle && <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>}
         {trend && (
           <p className={`text-xs mt-1 ${trend.isPositive ? "text-green-600" : "text-red-600"}`}>

--- a/codebenders-dashboard/components/risk-alert-chart.tsx
+++ b/codebenders-dashboard/components/risk-alert-chart.tsx
@@ -22,6 +22,8 @@ interface RiskAlertChartProps {
   data: RiskAlertData[]
   loading?: boolean
   info?: React.ReactNode
+  /** Click a slice to open data lineage for that alert level (issue #107). */
+  onSegmentLineage?: (category: string) => void
 }
 
 const COLORS = {
@@ -53,7 +55,9 @@ const CustomLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent }: an
 
 const CHART_FILE_SLUG = "risk-alert-distribution" as const
 
-export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartProps) {
+type PieSlicePayload = { name?: string }
+
+export function RiskAlertChart({ data, loading = false, info, onSegmentLineage }: RiskAlertChartProps) {
   const exportRef = useRef<HTMLDivElement>(null)
 
   const csvSpec = useMemo(
@@ -70,7 +74,10 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
             <CardTitle>Risk Alert Distribution</CardTitle>
             {info && <InfoPopover title="Risk Alert Distribution">{info}</InfoPopover>}
           </div>
-          <CardDescription>Students by risk level</CardDescription>
+          <CardDescription>
+            Students by risk level
+            {onSegmentLineage ? <span className="text-muted-foreground"> · Click a slice for data lineage</span> : null}
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="h-[300px] flex items-center justify-center">
@@ -89,7 +96,10 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
             <CardTitle>Risk Alert Distribution</CardTitle>
             {info && <InfoPopover title="Risk Alert Distribution">{info}</InfoPopover>}
           </div>
-          <CardDescription>Students by risk level</CardDescription>
+          <CardDescription>
+            Students by risk level
+            {onSegmentLineage ? <span className="text-muted-foreground"> · Click a slice for data lineage</span> : null}
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="h-[300px] flex items-center justify-center">
@@ -112,7 +122,10 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
     <Card ref={exportRef}>
       <CardHeader>
         <CardTitle>Risk Alert Distribution</CardTitle>
-        <CardDescription>{totalStudents.toLocaleString()} total students</CardDescription>
+        <CardDescription>
+          {totalStudents.toLocaleString()} total students
+          {onSegmentLineage ? <span className="text-muted-foreground"> · Click a slice for data lineage</span> : null}
+        </CardDescription>
         <ChartExportGlossaryBlurb slug="risk-alert-distribution" />
         <ChartExportDataSourceLine>
           student_level_with_predictions · at_risk_alert ·
@@ -144,6 +157,10 @@ export function RiskAlertChart({ data, loading = false, info }: RiskAlertChartPr
               outerRadius={100}
               fill="#8884d8"
               dataKey="value"
+              className={onSegmentLineage ? "cursor-pointer outline-none" : undefined}
+              onClick={(slice: PieSlicePayload) => {
+                if (slice.name && onSegmentLineage) onSegmentLineage(slice.name)
+              }}
             >
               {chartData.map((entry, index) => (
                 <Cell key={`cell-${index}`} fill={COLORS[entry.name as keyof typeof COLORS] || "#94a3b8"} />

--- a/codebenders-dashboard/components/ui/dialog.tsx
+++ b/codebenders-dashboard/components/ui/dialog.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "max-h-[90vh] max-w-2xl overflow-y-auto",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/codebenders-dashboard/lib/dashboard-filters.ts
+++ b/codebenders-dashboard/lib/dashboard-filters.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared WHERE clause for dashboard pages that filter `student_level_with_predictions`
+ * (home KPIs, charts, lineage). Column names match existing API routes.
+ */
+export type DashboardFilterParams = {
+  cohort: string
+  enrollmentType: string
+  credentialType: string
+}
+
+/** Query-string style object for lineage UI (omit empty keys). */
+export function optionalDashboardFilterRecord(
+  params: DashboardFilterParams
+): Record<string, string> {
+  return {
+    ...(params.cohort ? { cohort: params.cohort } : {}),
+    ...(params.enrollmentType ? { enrollmentType: params.enrollmentType } : {}),
+    ...(params.credentialType ? { credentialType: params.credentialType } : {}),
+  }
+}
+
+export function buildStudentLevelDashboardWhere(params: DashboardFilterParams): { clause: string; values: unknown[] } {
+  const conditions: string[] = []
+  const values: unknown[] = []
+
+  if (params.cohort) {
+    values.push(params.cohort)
+    conditions.push(`"Cohort" = $${values.length}`)
+  }
+  if (params.enrollmentType) {
+    values.push(params.enrollmentType)
+    conditions.push(`"Enrollment_Intensity_First_Term" = $${values.length}`)
+  }
+  if (params.credentialType) {
+    values.push(params.credentialType)
+    conditions.push(`predicted_credential_label = $${values.length}`)
+  }
+
+  const clause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
+  return { clause, values }
+}
+
+/** Alias columns with table prefix `s.` for use in subqueries / JOINs. */
+export function buildStudentLevelDashboardWhereAliased(
+  params: DashboardFilterParams,
+  tableAlias = "s"
+): { clause: string; values: unknown[] } {
+  const { conditions, values } = buildStudentLevelDashboardConditionsAliased(params, tableAlias)
+  const clause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
+  return { clause, values }
+}
+
+/** Condition fragments (no `WHERE`) so callers can `AND` with lineage predicates. */
+export function buildStudentLevelDashboardConditionsAliased(
+  params: DashboardFilterParams,
+  tableAlias = "s"
+): { conditions: string[]; values: unknown[] } {
+  const conditions: string[] = []
+  const values: unknown[] = []
+
+  if (params.cohort) {
+    values.push(params.cohort)
+    conditions.push(`${tableAlias}."Cohort" = $${values.length}`)
+  }
+  if (params.enrollmentType) {
+    values.push(params.enrollmentType)
+    conditions.push(`${tableAlias}."Enrollment_Intensity_First_Term" = $${values.length}`)
+  }
+  if (params.credentialType) {
+    values.push(params.credentialType)
+    conditions.push(`${tableAlias}.predicted_credential_label = $${values.length}`)
+  }
+
+  return { conditions, values }
+}

--- a/codebenders-dashboard/lib/lineage-config.ts
+++ b/codebenders-dashboard/lib/lineage-config.ts
@@ -1,0 +1,187 @@
+import { SCHEMAS, type UploadSchema } from "@/lib/upload-schemas"
+
+/** Upload schema IDs that write to `student_level_with_predictions` (for latest-ingest lookup). */
+export const LINEAGE_STUDENT_LEVEL_SCHEMA_IDS: string[] = Array.from(
+  new Set(
+    SCHEMAS.filter((s: UploadSchema) => s.targetTable === "student_level_with_predictions").map(
+      (s) => s.id
+    )
+  )
+)
+
+export const LINEAGE_METRICS = [
+  "overall_retention",
+  "avg_predicted_retention",
+  "high_critical_risk_count",
+  "avg_course_completion",
+  "risk_alert_segment",
+  "retention_risk_segment",
+  "roster_cell",
+] as const
+
+export type LineageMetricId = (typeof LINEAGE_METRICS)[number]
+
+export function isLineageMetricId(s: string): s is LineageMetricId {
+  return (LINEAGE_METRICS as readonly string[]).includes(s)
+}
+
+export type LineageTransformStep = {
+  order: number
+  title: string
+  detail: string
+}
+
+export function lineageStepsForMetric(metric: LineageMetricId): LineageTransformStep[] {
+  const base: LineageTransformStep[] = [
+    {
+      order: 1,
+      title: "Institutional ingest",
+      detail:
+        "Rows are loaded into `student_level_with_predictions` via the admin upload wizard (PDP / AR / submission layouts). Each commit records an `upload_history` event with validation summary.",
+    },
+    {
+      order: 2,
+      title: "Analysis-ready view",
+      detail:
+        "The dashboard reads the `student_level_with_predictions` view (one row per student). Dashboard filters (cohort, enrollment intensity, predicted credential) scope the same row set used for KPIs and charts.",
+    },
+  ]
+
+  switch (metric) {
+    case "overall_retention":
+      return [
+        ...base,
+        {
+          order: 3,
+          title: "Aggregate: historical retention",
+          detail:
+            "KPI = AVG(`Retention`) × 100 over filtered students. `Retention` is the cohort year-to-year retention indicator from PDP-style source data (0 = not retained, 1 = retained).",
+        },
+      ]
+    case "avg_predicted_retention":
+      return [
+        ...base,
+        {
+          order: 3,
+          title: "Model: retention probability",
+          detail:
+            "KPI = AVG(`retention_probability`) × 100. Probabilities come from the deployed XGBoost retention classifier (features include demographics, placement, GPA, and course performance). Values are refreshed when prediction scores are merged into the student-level table (upload or ML pipeline).",
+        },
+      ]
+    case "high_critical_risk_count":
+      return [
+        ...base,
+        {
+          order: 3,
+          title: "Composite: alert bucketing",
+          detail:
+            "Count of students where `at_risk_alert` is HIGH or URGENT. Alerts combine inverted retention probability with GPA, course completion, and credit-progress thresholds (see methodology).",
+        },
+      ]
+    case "avg_course_completion":
+      return [
+        ...base,
+        {
+          order: 3,
+          title: "Aggregate: course completion rate",
+          detail:
+            "KPI = AVG(`course_completion_rate`) × 100 over filtered students (credits earned ÷ attempted in the modeled window).",
+        },
+      ]
+    case "risk_alert_segment":
+      return [
+        ...base,
+        {
+          order: 3,
+          title: "Slice: risk alert level",
+          detail:
+            "Chart segment counts students with a given `at_risk_alert` value (URGENT, HIGH, MODERATE, LOW) within the filtered cohort.",
+        },
+      ]
+    case "retention_risk_segment":
+      return [
+        ...base,
+        {
+          order: 3,
+          title: "Slice: retention probability band",
+          detail:
+            "Chart segment buckets students by `retention_risk_category` derived from `retention_probability` cut points (Critical / High / Moderate / Low risk).",
+        },
+      ]
+    case "roster_cell":
+      return [
+        ...base,
+        {
+          order: 3,
+          title: "Roster column",
+          detail:
+            "Value shown is taken from the same `student_level_with_predictions` row (and readiness join where applicable) as the student roster API.",
+        },
+      ]
+  }
+}
+
+export const ROSTER_LINEAGE_FIELD_KEYS = [
+  "retention_pct",
+  "readiness_pct",
+  "gateway_math_pct",
+  "gateway_english_pct",
+  "gpa_risk_pct",
+  "time_to_credential",
+  "credential_type",
+  "at_risk_alert",
+  "cohort",
+  "enrollment_intensity",
+] as const
+
+export type RosterLineageField = (typeof ROSTER_LINEAGE_FIELD_KEYS)[number]
+
+export function isRosterLineageField(s: string): s is RosterLineageField {
+  return (ROSTER_LINEAGE_FIELD_KEYS as readonly string[]).includes(s)
+}
+
+export function rosterFieldLineageLabel(field: RosterLineageField): { label: string; detail: string } {
+  const map = {
+    retention_pct: {
+      label: "Predicted retention %",
+      detail: "`retention_probability` on `student_level_with_predictions`, scaled ×100 and rounded (XGBoost retention model).",
+    },
+    readiness_pct: {
+      label: "Readiness %",
+      detail: "`readiness_score` from `llm_recommendations`, joined by `Student_GUID`, scaled ×100 and rounded.",
+    },
+    gateway_math_pct: {
+      label: "Gateway math %",
+      detail: "`gateway_math_probability` on `student_level_with_predictions` (ML model output).",
+    },
+    gateway_english_pct: {
+      label: "Gateway English %",
+      detail: "`gateway_english_probability` on `student_level_with_predictions` (ML model output).",
+    },
+    gpa_risk_pct: {
+      label: "Low-GPA risk %",
+      detail: "`low_gpa_probability` on `student_level_with_predictions` (ML model output).",
+    },
+    time_to_credential: {
+      label: "Time to credential",
+      detail: "`predicted_time_to_credential` regression output on `student_level_with_predictions`.",
+    },
+    credential_type: {
+      label: "Credential type",
+      detail: "`predicted_credential_label` on `student_level_with_predictions` (predicted credential category).",
+    },
+    at_risk_alert: {
+      label: "At-risk alert",
+      detail: "`at_risk_alert` composite bucket (URGENT / HIGH / MODERATE / LOW) on `student_level_with_predictions`.",
+    },
+    cohort: {
+      label: "Cohort",
+      detail: "`Cohort` dimension on `student_level_with_predictions` (PDP cohort label).",
+    },
+    enrollment_intensity: {
+      label: "Enrollment intensity",
+      detail: "`Enrollment_Intensity_First_Term` on `student_level_with_predictions`.",
+    },
+  } satisfies Record<RosterLineageField, { label: string; detail: string }>
+  return map[field]
+}

--- a/codebenders-dashboard/lib/lineage-types.ts
+++ b/codebenders-dashboard/lib/lineage-types.ts
@@ -1,0 +1,38 @@
+import type { LineageTransformStep } from "@/lib/lineage-config"
+
+export type LineageUploadEvent = {
+  id: number
+  filename: string
+  fileType: string
+  schemaLabel: string
+  uploadedAt: string
+  status: string
+  userEmail: string | null
+  rowsInserted: number
+  rowsSkipped: number
+  errorCount: number
+  hasValidationReport: boolean
+}
+
+export type LineageApiResponse = {
+  metricId: string
+  metricLabel: string
+  metricDescription: string
+  field?: string
+  filters: Record<string, string>
+  dimension?: string
+  aggregate: {
+    rowCount: number
+    summary: string
+  }
+  sourceRowsVisible: boolean
+  sourceRowsRestrictedMessage?: string
+  sourceRows?: {
+    page: number
+    pageSize: number
+    total: number
+    rows: Record<string, unknown>[]
+  }
+  uploadEvent: LineageUploadEvent | null
+  transformationSteps: LineageTransformStep[]
+}

--- a/codebenders-dashboard/package.json
+++ b/codebenders-dashboard/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.56",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "2.1.7",
     "@radix-ui/react-popover": "^1.1.15",


### PR DESCRIPTION
## Summary
Implements the data lineage MVP from issue #107: users can trace **where dashboard numbers come from** via an ingest event, transformation chain, and (when permitted) paginated source rows.

## What changed
- **`GET /api/lineage`** — Accepts `metric`, dashboard filters (`cohort`, `enrollmentType`, `credentialType`), optional `category` for chart segments, and `studentGuid` + `field` for roster cells. Returns latest relevant `upload_history` row, static transformation steps, aggregate row count, and paginated rows from `student_level_with_predictions`.
- **RBAC** — Source rows with student GUIDs are returned only for roles that can access `/api/students` (admin, advisor, IR). Other authenticated roles still see upload metadata, steps, and counts.
- **UI** — Radix Dialog–based drawer; wired from home KPI values (click the number), risk alert pie slices, and roster table cells (`LineageValueButton` + `stopPropagation` so row navigation still works).
- **Shared helpers** — `lib/dashboard-filters.ts`, `lib/lineage-config.ts`, `lib/lineage-types.ts`; `@radix-ui/react-dialog` dependency.

## How to verify
```bash
cd codebenders-dashboard && npm run lint && npm test && npm run build
```

Closes #107 (if your repo uses that keyword).

Made with [Cursor](https://cursor.com)