### PR TITLE
docs(discovery): update AASCU brief + full report with shipped status (6 of 8 + 4 follow-ups)

### DIFF
--- a/codebenders-dashboard/app/discovery/aascu/full/page.module.css
+++ b/codebenders-dashboard/app/discovery/aascu/full/page.module.css
@@ -472,6 +472,16 @@
 }
 .cardLink::after { content: " →"; }
 
+.cardShipped {
+  border-color: var(--accent);
+  box-shadow: inset 4px 0 0 var(--accent);
+}
+.cardShipped .cardLink {
+  color: var(--accent);
+  font-weight: 500;
+}
+.cardShipped .cardLink::after { content: " ✓"; }
+
 .summary {
   display: grid;
   grid-template-columns: 1fr 2fr;

--- a/codebenders-dashboard/app/discovery/aascu/full/page.tsx
+++ b/codebenders-dashboard/app/discovery/aascu/full/page.tsx
@@ -93,17 +93,20 @@ const COVERAGE: Array<{
   status: "done" | "partial"
   statusLabel: string
 }> = [
-  { pp: "C · Export", name: "CSV export wired into dashboard", ev: <><code>components/export-button.tsx</code> · issue #15</>, status: "done", statusLabel: "Done" },
+  { pp: "C · Export", name: "CSV export + presentation-ready PNG / PDF chart export", ev: <>CSV (#15) · PNG/PDF with embedded definitions (#106 · PR #137)</>, status: "done", statusLabel: "Done" },
   { pp: "C · Visualization", name: "Recharts components, types chosen per metric", ev: <><code>retention-risk-chart.tsx</code>, <code>risk-alert-chart.tsx</code>, <code>readiness-assessment-chart.tsx</code></>, status: "done", statusLabel: "Done" },
-  { pp: "B · Definitions", name: "Tooltip primitive exists; no centralized glossary yet", ev: <><code>components/info-popover.tsx</code></>, status: "partial", statusLabel: "Partial" },
+  { pp: "B · Definitions", name: "Glossary with IPEDS / state cross-walks + chart deep-links", ev: <>Issues #105 (PR #135) and #124 (PR #136) shipped</>, status: "done", statusLabel: "Done" },
   { pp: "D · Methodology", name: "How predictions are made — surfaced in-app", ev: <><code>app/methodology/</code> route</>, status: "done", statusLabel: "Done" },
-  { pp: "D · FERPA", name: "RBAC, audit log, FERPA-compliant identity resolution", ev: <>Issues #67, #75, #77, #78 (closed)</>, status: "done", statusLabel: "Done" },
-  { pp: "D · Automation", name: "Self-service upload (PDP, AR, student, course)", ev: <>Issue #86 (closed) · <code>components/upload/</code></>, status: "done", statusLabel: "Done" },
+  { pp: "D · FERPA", name: "RBAC, audit log, identity resolution, NLQ runtime guard", ev: <>Originals: #67, #75, #77, #78 · NLQ guard #127 (PR #132) · FERPA-audit skill #129 (PR #134)</>, status: "done", statusLabel: "Done" },
+  { pp: "D · Transparency", name: "AI Transparency page — model + LLM + data-API inventory", ev: <>Issue #108 (PR #128) · simplified in PR #131</>, status: "done", statusLabel: "Done" },
+  { pp: "D · Lineage", name: "Click any number → source rows, upload event, transformations", ev: <>Issue #107 (PR #139)</>, status: "done", statusLabel: "Done" },
+  { pp: "D · Sensitive populations", name: "Per-institution feature exclusion, low-N warnings, audit log", ev: <>Issue #109 shipped (commit 163dfea)</>, status: "done", statusLabel: "Done" },
+  { pp: "D · Automation", name: "Self-service upload + on-prem-only NLQ option", ev: <>Upload: #86 · <code>FORCE_DIRECT_DB</code> hardening flag #126 (PR #133)</>, status: "done", statusLabel: "Done" },
   { pp: "D · Explainability", name: "SHAP narrator — fine-tuning epic in progress", ev: <>Issues #97 — #103 · branch <code>fine-tuning/97-shap-narrator-task-type</code></>, status: "partial", statusLabel: "In flight" },
-  { pp: "A · Validation", name: "Upload exists; human-readable validation report missing", ev: <>Addressed by new issue #110</>, status: "partial", statusLabel: "Partial" },
+  { pp: "A · Validation", name: "Row-level errors, coercions, dedup decisions, diff vs. last upload", ev: <>Issue #110 (PR #138)</>, status: "done", statusLabel: "Done" },
   { pp: "C · Filtering", name: "By cohort, term, demographic, credential type", ev: <>Issues #66, #81 (closed)</>, status: "done", statusLabel: "Done" },
-  { pp: "C · Query", name: "Natural-language query against the data", ev: <><code>lib/prompt-analyzer.ts</code> · issues #17, #61, #88, #90</>, status: "done", statusLabel: "Done" },
-  { pp: "E · Knowledge", name: "Self-service upload reduces single-person dependency", ev: <>In-app submission runbook missing — addressed by #111</>, status: "partial", statusLabel: "Partial" },
+  { pp: "C · Query", name: "Natural-language query — LLM-backed analyzer + rule-based fallback", ev: <><code>app/api/analyze/</code> · <code>lib/prompt-analyzer.ts</code> · issues #17, #61, #88, #90</>, status: "done", statusLabel: "Done" },
+  { pp: "E · Knowledge", name: "Self-service upload + validation report; runbook generator outstanding", ev: <>Helped by #86 + #110 · in-app runbook still on #111</>, status: "partial", statusLabel: "Partial" },
 ]
 
 const TIERS: Array<{
@@ -111,16 +114,22 @@ const TIERS: Array<{
   pillLabel: string
   h: React.ReactNode
   twoCol?: boolean
-  cards: Array<{ num: number; tag: string; title: string; body: React.ReactNode }>
+  cards: Array<{
+    num: number
+    tag: string
+    title: string
+    body: React.ReactNode
+    shipped?: { pr?: number }
+  }>
 }> = [
   {
     pri: "p0",
     pillLabel: "P0 · Differentiators",
     h: <>Match the loudest complaints. <em>Datathon-eligible.</em></>,
     cards: [
-      { num: 105, tag: "Pain B · Definitions", title: "Metric definitions glossary with IPEDS & state-compliance cross-walks", body: <>Every KPI surfaces a tooltip with PDP, IPEDS, and state-compliance equivalents. Centralized <code>/glossary</code> page indexed by metric. Markdown source-of-truth, versioned with the code.</> },
-      { num: 106, tag: "Pain C · Export", title: "Presentation-ready chart export (PNG / PDF)", body: <>Every chart exports as a polished image with title, definition, source, and date stamp baked in. Eliminates the manual Excel-rebuild workflow IR staff perform daily.</> },
-      { num: 107, tag: "Pain A + D · Lineage", title: "Data lineage view — “where did this number come from”", body: <>Click any number → see source rows, upload event, transformations, and timestamps. The single highest-leverage gap from the session: directly answers trust + governance + differentiation in one feature.</> },
+      { num: 105, tag: "Pain B · Definitions", title: "Metric definitions glossary with IPEDS & state-compliance cross-walks", body: <>Every KPI surfaces a tooltip with PDP, IPEDS, and state-compliance equivalents. Centralized <code>/glossary</code> page indexed by metric. Markdown source-of-truth, versioned with the code.</>, shipped: { pr: 135 } },
+      { num: 106, tag: "Pain C · Export", title: "Presentation-ready chart export (PNG / PDF)", body: <>Every chart exports as a polished image with title, definition, source, and date stamp baked in. Eliminates the manual Excel-rebuild workflow IR staff perform daily.</>, shipped: { pr: 137 } },
+      { num: 107, tag: "Pain A + D · Lineage", title: "Data lineage view — “where did this number come from”", body: <>Click any number → see source rows, upload event, transformations, and timestamps. The single highest-leverage gap from the session: directly answers trust + governance + differentiation in one feature.</>, shipped: { pr: 139 } },
     ],
   },
   {
@@ -128,9 +137,9 @@ const TIERS: Array<{
     pillLabel: "P1 · Governance hardening",
     h: <>Table-stakes for institutional adoption.</>,
     cards: [
-      { num: 108, tag: "Pain D · Transparency", title: "AI Transparency Page", body: <>Per-model disclosure: features used, training data source, homegrown vs. third-party, where data flows when invoked, retention policy. Reviewable independently by institutional IT &amp; legal.</> },
-      { num: 109, tag: "Pain D · Sensitive populations", title: "Sensitive-population safeguards", body: <>Per-institution feature-exclusion lists. Context warnings on small sub-populations. Audit log entries for any query touching flagged groups. Demoable, not just claimed.</> },
-      { num: 110, tag: "Pain A + E · Validation", title: "Upload validation report — diff vs. last upload", body: <>Row-level errors, field coercions, dedup decisions, anomaly flags (&ldquo;3 campuses dropped from this upload&rdquo;). Readable by non-technical IR staff. Survives the &ldquo;person retires&rdquo; scenario.</> },
+      { num: 108, tag: "Pain D · Transparency", title: "AI Transparency Page", body: <>Per-model disclosure: features used, training data source, homegrown vs. third-party, where data flows when invoked, retention policy. Reviewable independently by institutional IT &amp; legal.</>, shipped: { pr: 128 } },
+      { num: 109, tag: "Pain D · Sensitive populations", title: "Sensitive-population safeguards", body: <>Per-institution feature-exclusion lists. Context warnings on small sub-populations. Audit log entries for any query touching flagged groups. Demoable, not just claimed.</>, shipped: {} },
+      { num: 110, tag: "Pain A + E · Validation", title: "Upload validation report — diff vs. last upload", body: <>Row-level errors, field coercions, dedup decisions, anomaly flags (&ldquo;3 campuses dropped from this upload&rdquo;). Readable by non-technical IR staff. Survives the &ldquo;person retires&rdquo; scenario.</>, shipped: { pr: 138 } },
     ],
   },
   {
@@ -143,6 +152,13 @@ const TIERS: Array<{
       { num: 112, tag: "Pain F · Datathon coordination", title: "Institution-grouping helper — shared SIS + shared goal", body: <>Operational artifact, not a user feature: cross-reference AASCU&rsquo;s SIS list with stated institutional goals; output a candidate cohort matrix for the fall datathon.</> },
     ],
   },
+]
+
+const FOLLOWUPS: Array<{ num: number; title: string; body: React.ReactNode; shipped: { pr?: number } }> = [
+  { num: 125, title: "Docs drift — 6 ML models + 3 OpenAI surfaces", body: <>Authoring the transparency page surfaced documentation inaccuracies in <code>CLAUDE.md</code> and <code>README.md</code>. Updated to match code reality.</>, shipped: { pr: 130 } },
+  { num: 126, title: "FORCE_DIRECT_DB — block external NLQ data flow", body: <>Deployment-hardening flag for institutions that require fully on-prem data paths. Default off; flips an institutional procurement gate when set.</>, shipped: { pr: 133 } },
+  { num: 127, title: "FERPA runtime guard for NLQ-generated SQL", body: <>Static check that LLM-produced SQL never SELECTs <code>Student_GUID</code>. Backs the policy disclosed on the transparency page with code-level enforcement.</>, shipped: { pr: 132 } },
+  { num: 129, title: "FERPA-audit Claude Code skill", body: <>Repeatable static + DB read-time leak detection. Catches gaps like #126 and #127 proactively on every PR rather than retrospectively on the next transparency rewrite.</>, shipped: { pr: 134 } },
 ]
 
 const pillClass = (pri: "p0" | "p1" | "p2") =>
@@ -176,8 +192,8 @@ export default function AASCUFullPage() {
           <dl className={styles.strip}>
             <div><dt>Recording</dt><dd>20:58<small>minutes of testimony</small></dd></div>
             <div><dt>Voices</dt><dd>2<small>intermediaries · IR + data&#8209;eng</small></dd></div>
-            <div><dt>Pain themes</dt><dd>6<small>mapped across stack</small></dd></div>
             <div><dt>Issues filed</dt><dd>8<small>#105 — #112</small></dd></div>
+            <div><dt>Shipped</dt><dd>6<small>of 8 · plus 4 follow-ups</small></dd></div>
           </dl>
         </section>
 
@@ -200,7 +216,7 @@ export default function AASCUFullPage() {
             </aside>
             <div className="body">
               <p>Two AASCU intermediaries described pain in three layers: <strong>PDP dashboard quality</strong> — inaccurate cohort numbers, buried definitions, wrong chart types, no data export — forcing IR staff into manual Excel rebuilds; <strong>AI/governance requirements</strong> — FERPA-plus expectations including data lineage, transparency, and explicit safeguards for sensitive student populations; and <strong>institutional process gaps</strong> — submission knowledge that lives with one person and varies wildly across campuses.</p>
-              <p>Our tool already addresses a meaningful share of layer one — CSV export, sane chart types, NLQ, methodology page — and is in-flight on layer two via the SHAP-narrator work. The biggest unaddressed gaps are <em>a definitions glossary with IPEDS / state-compliance cross-walks, presentation-ready chart export, a data-lineage view that proves where each number came from, and AI transparency + sensitive-population safeguards as a precondition for institutional adoption.</em></p>
+              <p><strong>Update:</strong> six of the eight issues filed have shipped — including all four originally identified as &ldquo;the biggest unaddressed gaps&rdquo;: the definitions glossary with IPEDS / state cross-walks, presentation-ready chart export, the data-lineage view, and AI transparency. Sensitive-population safeguards (#109) and the upload validation report (#110) also shipped. The remaining open work is the submission-runbook generator (#111) and the datathon institution-grouping spike (#112). Authoring the transparency page surfaced four additional follow-ups (#125 — #129) which have all also shipped — see chapter 05.</p>
             </div>
           </div>
         </section>
@@ -287,7 +303,7 @@ export default function AASCUFullPage() {
                 {tier.cards.map((c) => (
                   <a
                     key={c.num}
-                    className={styles.card}
+                    className={`${styles.card} ${c.shipped ? styles.cardShipped : ""}`}
                     href={`${ISSUE_BASE}/${c.num}`}
                     target="_blank"
                     rel="noreferrer"
@@ -299,7 +315,13 @@ export default function AASCUFullPage() {
                     <div className={styles.cardTag}>{c.tag}</div>
                     <h4 className={styles.cardH}>{c.title}</h4>
                     <p className={styles.cardP}>{c.body}</p>
-                    <div className={styles.cardLink}>Open issue</div>
+                    <div className={styles.cardLink}>
+                      {c.shipped
+                        ? c.shipped.pr
+                          ? `Shipped · PR #${c.shipped.pr}`
+                          : "Shipped"
+                        : "Open issue"}
+                    </div>
                   </a>
                 ))}
               </div>
@@ -316,10 +338,42 @@ export default function AASCUFullPage() {
           </div>
         </section>
 
+        <section className={styles.chapter}>
+          <div className={styles.chapHead}>
+            <div className={styles.chapNum}>05<span>Follow-ups</span></div>
+            <div>
+              <h2 className={styles.chapTitle}>What we found <em>by building</em> — and shipped before this update.</h2>
+              <p className={styles.chapKicker}>Authoring the AI Transparency Page (#108) surfaced four hardening gaps that weren&rsquo;t visible from the original discovery session: drifted documentation, an undocumented external data flow, a FERPA policy enforced only by prompt, and the absence of a repeatable audit. All four are now shipped.</p>
+            </div>
+          </div>
+          <div className={`${styles.cards} ${styles.cardsTwo}`}>
+            {FOLLOWUPS.map((c) => (
+              <a
+                key={c.num}
+                className={`${styles.card} ${styles.cardShipped}`}
+                href={`${ISSUE_BASE}/${c.num}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <div className={styles.cardNum}>
+                  <span>Issue</span>
+                  <b>#{c.num}</b>
+                </div>
+                <div className={styles.cardTag}>Follow-up · transparency-driven</div>
+                <h4 className={styles.cardH}>{c.title}</h4>
+                <p className={styles.cardP}>{c.body}</p>
+                <div className={styles.cardLink}>
+                  {c.shipped.pr ? `Shipped · PR #${c.shipped.pr}` : "Shipped"}
+                </div>
+              </a>
+            ))}
+          </div>
+        </section>
+
         <footer className={styles.colophon}>
           <div>
             <b>AASCU Intermediary Discovery</b> · Gap Analysis<br />
-            Set in Fraunces &amp; IBM Plex Sans · Filed 2026·04·29
+            Set in Fraunces &amp; IBM Plex Sans · Filed 2026·04·29 · Updated 2026·05·03
           </div>
           <div>
             Codebenders&nbsp;Datathon · <b>Bishop&nbsp;State&nbsp;CC</b>

--- a/codebenders-dashboard/app/discovery/aascu/page.module.css
+++ b/codebenders-dashboard/app/discovery/aascu/page.module.css
@@ -223,6 +223,28 @@
 .pri1 { color: var(--partial); border-color: var(--partial); }
 .pri2 { color: var(--muted); }
 
+.shipped {
+  color: var(--done);
+  border-color: var(--done);
+  background: var(--accent-soft);
+}
+
+.pillStack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.followNote {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--soft);
+  margin-top: -8px;
+  margin-bottom: 18px;
+  max-width: 620px;
+}
+
 .footer {
   margin-top: 48px;
   padding-top: 20px;

--- a/codebenders-dashboard/app/discovery/aascu/page.tsx
+++ b/codebenders-dashboard/app/discovery/aascu/page.tsx
@@ -33,15 +33,23 @@ const ISSUES: Array<{
   title: string
   desc: string
   pri: "p0" | "p1" | "p2"
+  shipped?: { pr?: number; note?: string }
 }> = [
-  { num: 105, pri: "p0", title: "Metric definitions glossary with IPEDS / state cross-walks", desc: "Hover tooltips on every KPI · centralized /glossary page · markdown source-of-truth." },
-  { num: 106, pri: "p0", title: "Presentation-ready chart export (PNG / PDF)", desc: "Title, definition, source, date stamp baked in. Eliminates the manual Excel rebuild." },
-  { num: 107, pri: "p0", title: "Data lineage view — “where did this number come from”", desc: "Click any number → source rows, upload event, transformations, timestamps. Highest-leverage gap." },
-  { num: 108, pri: "p1", title: "AI Transparency Page", desc: "Per-model disclosure — features, training data, provider, data flow, retention. Reviewable independently." },
-  { num: 109, pri: "p1", title: "Sensitive-population safeguards", desc: "Per-institution feature exclusion · low-sample-size context warnings · audit log entries." },
-  { num: 110, pri: "p1", title: "Upload validation report — diff vs. last upload", desc: "Row-level errors, coercions, dedup decisions, dropped-campus flags. Readable by non-technical IR staff." },
+  { num: 105, pri: "p0", title: "Metric definitions glossary with IPEDS / state cross-walks", desc: "Hover tooltips on every KPI · centralized /glossary page · markdown source-of-truth.", shipped: { pr: 135 } },
+  { num: 106, pri: "p0", title: "Presentation-ready chart export (PNG / PDF)", desc: "Title, definition, source, date stamp baked in. Eliminates the manual Excel rebuild.", shipped: { pr: 137 } },
+  { num: 107, pri: "p0", title: "Data lineage view — “where did this number come from”", desc: "Click any number → source rows, upload event, transformations, timestamps. Highest-leverage gap.", shipped: { pr: 139 } },
+  { num: 108, pri: "p1", title: "AI Transparency Page", desc: "Per-model disclosure — features, training data, provider, data flow, retention. Reviewable independently.", shipped: { pr: 128 } },
+  { num: 109, pri: "p1", title: "Sensitive-population safeguards", desc: "Per-institution feature exclusion · low-sample-size context warnings · audit log entries.", shipped: {} },
+  { num: 110, pri: "p1", title: "Upload validation report — diff vs. last upload", desc: "Row-level errors, coercions, dedup decisions, dropped-campus flags. Readable by non-technical IR staff.", shipped: { pr: 138 } },
   { num: 111, pri: "p2", title: "Submission runbook generator", desc: "Capture what worked → printable runbook · replayable on new files · survives staff turnover." },
   { num: 112, pri: "p2", title: "Datathon institution grouping (SIS + goal)", desc: "Operational artifact — cross-reference AASCU's SIS list with stated goals; output cohort matrix." },
+]
+
+const FOLLOWUPS: Array<{ num: number; title: string; desc: string; shipped?: { pr?: number } }> = [
+  { num: 125, title: "Docs drift — 6 ML models + 3 OpenAI surfaces", desc: "Authoring the transparency page surfaced doc inaccuracies. CLAUDE.md + README updated.", shipped: { pr: 130 } },
+  { num: 126, title: "FORCE_DIRECT_DB hardening flag", desc: "Block external data API for institutions that require fully on-prem NLQ.", shipped: { pr: 133 } },
+  { num: 127, title: "FERPA runtime guard for NLQ-generated SQL", desc: "Static check that LLM-produced SQL never SELECTs Student_GUID.", shipped: { pr: 132 } },
+  { num: 129, title: "FERPA-audit Claude Code skill", desc: "Repeatable static + DB read-time leak detection. Catches the same gaps proactively on every PR.", shipped: { pr: 134 } },
 ]
 
 const COVERAGE: Array<{
@@ -50,13 +58,13 @@ const COVERAGE: Array<{
   desc: string
   status: "done" | "partial" | "gap"
 }> = [
-  { lbl: "A · Data accuracy", status: "partial", title: "Numbers don’t add up; PDP pulls from wrong dataset", desc: "Validation report on upload addresses the institutional side; PDP-side accuracy is out of scope." },
-  { lbl: "B · Definitions", status: "gap", title: "Metrics undefined in-context; mismatch with IPEDS / state", desc: "Tooltip primitive exists. Centralized glossary and cross-walks not yet built." },
-  { lbl: "C · Visualization", status: "done", title: "Wrong chart types in PDP; ours are sane", desc: "Recharts components, types chosen per metric. Done." },
-  { lbl: "C · Export", status: "partial", title: "CSV from dashboard; no presentation-ready chart export", desc: "CSV shipped (#15). PNG/PDF export with embedded definitions is the next step." },
-  { lbl: "D · FERPA", status: "done", title: "RBAC, audit log, FERPA-compliant identity resolution", desc: "Issues #67, #75, #77, #78 closed. FERPA basics covered." },
-  { lbl: "D · AI governance", status: "gap", title: "Transparency page, lineage view, sensitive-population safeguards", desc: "Methodology page exists. SHAP narrator in flight. Lineage and transparency disclosures unbuilt." },
-  { lbl: "E · Process", status: "partial", title: "Knowledge siloed; submission rituals vary per campus", desc: "Self-service upload (#86) helps. Runbook generator would close the loop." },
+  { lbl: "A · Data accuracy", status: "done", title: "Numbers don’t add up; PDP pulls from wrong dataset", desc: "Lineage view (#107) makes every number provable; validation report (#110) catches errors at upload time. PDP-side accuracy is out of scope." },
+  { lbl: "B · Definitions", status: "done", title: "Metrics undefined in-context; mismatch with IPEDS / state", desc: "Glossary with IPEDS + state cross-walks shipped (#105); deep-linked from charts (#136)." },
+  { lbl: "C · Visualization", status: "done", title: "Wrong chart types in PDP; ours are sane", desc: "Recharts components, types chosen per metric." },
+  { lbl: "C · Export", status: "done", title: "Presentation-ready PNG / PDF chart export with definitions baked in", desc: "Shipped (#106) on top of the existing CSV path (#15)." },
+  { lbl: "D · FERPA", status: "done", title: "RBAC, audit log, identity resolution, NLQ runtime guard", desc: "Original FERPA work (#67, #75, #77, #78) plus runtime SQL guard (#127) and the FERPA-audit skill (#129) for ongoing PR-time enforcement." },
+  { lbl: "D · AI governance", status: "done", title: "Transparency page, lineage view, sensitive-population safeguards", desc: "AI Transparency (#108), data lineage (#107), sensitive-population safeguards (#109) — all shipped. SHAP narrator (#97-#103) still in flight." },
+  { lbl: "E · Process", status: "partial", title: "Knowledge siloed; submission rituals vary per campus", desc: "Self-service upload (#86) and validation report (#110) help. Submission runbook (#111) would close the loop — not yet shipped." },
 ]
 
 const statClass = (s: "done" | "partial" | "gap") =>
@@ -80,18 +88,18 @@ export default function AASCUBriefPage() {
             <span><b>2026·04·29</b></span>
             <span>2 intermediaries</span>
             <span>21 min source</span>
-            <span>8 issues filed</span>
+            <span>8 filed · 6 shipped</span>
           </div>
         </header>
 
         <section className={styles.section}>
-          <h2 className={styles.h2}>The take</h2>
+          <h2 className={styles.h2}>The take · update</h2>
           <div className={styles.tldr}>
             <p>
-              Intermediaries describe pain in three layers: <strong>PDP dashboard quality</strong> (charts, definitions, exports, accuracy), <strong>AI &amp; data governance</strong> (lineage, transparency, sensitive populations), and <strong>institutional process</strong> (knowledge silos, inconsistent submission rituals).
+              Intermediaries described pain in three layers: <strong>PDP dashboard quality</strong>, <strong>AI &amp; data governance</strong>, and <strong>institutional process</strong>. Six of the eight issues filed against the codebase have shipped — including the four named &ldquo;biggest unaddressed gaps&rdquo; in this brief&rsquo;s first publication.
             </p>
             <p>
-              The tool already addresses meaningful parts of layer one and is in-flight on layer two via the SHAP narrator. The biggest unaddressed gaps are <strong>a definitions glossary, presentation-ready chart export, a data-lineage view, and AI transparency + sensitive-population safeguards</strong>.
+              <strong>Shipped:</strong> definitions glossary with IPEDS / state cross-walks, presentation-ready chart export, data-lineage view, AI transparency page, sensitive-population safeguards, upload validation report. <strong>Outstanding:</strong> submission runbook generator (#111), datathon institution-grouping spike (#112).
             </p>
           </div>
         </section>
@@ -127,7 +135,42 @@ export default function AASCUBriefPage() {
                 <h3 className={styles.issueH}>{iss.title}</h3>
                 <p className={styles.issueP}>{iss.desc}</p>
               </div>
-              <span className={`${styles.pri} ${priClass(iss.pri)}`}>{iss.pri.toUpperCase()}</span>
+              <div className={styles.pillStack}>
+                {iss.shipped ? (
+                  <span className={`${styles.pri} ${styles.shipped}`}>
+                    {iss.shipped.pr ? `Shipped · PR #${iss.shipped.pr}` : "Shipped"}
+                  </span>
+                ) : (
+                  <span className={`${styles.pri} ${priClass(iss.pri)}`}>{iss.pri.toUpperCase()}</span>
+                )}
+              </div>
+            </a>
+          ))}
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.h2}>Follow-ups discovered during implementation</h2>
+          <p className={styles.followNote}>
+            Building #108 (transparency page) surfaced four hardening gaps that weren&rsquo;t visible from the original discovery session. All four are now shipped.
+          </p>
+          {FOLLOWUPS.map((iss) => (
+            <a
+              key={iss.num}
+              className={styles.issue}
+              href={`${ISSUE_BASE}/${iss.num}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <div className={styles.issueNum}>#{iss.num}</div>
+              <div>
+                <h3 className={styles.issueH}>{iss.title}</h3>
+                <p className={styles.issueP}>{iss.desc}</p>
+              </div>
+              <div className={styles.pillStack}>
+                <span className={`${styles.pri} ${styles.shipped}`}>
+                  {iss.shipped?.pr ? `Shipped · PR #${iss.shipped.pr}` : "Shipped"}
+                </span>
+              </div>
             </a>
           ))}
         </section>


### PR DESCRIPTION
## Summary

Updates `/discovery/aascu` and `/discovery/aascu/full` to reflect that 6 of the 8 spring-convening issues have shipped, plus 4 follow-ups discovered while building. The pages had grown stale — the original brief listed the lineage view, transparency page, and glossary as the *biggest unaddressed gaps*, and all three are now in production.

## What changed

### Brief page (`/discovery/aascu`)
- Each issue card now shows either a **Shipped · PR #N** pill (green, accent-tinted) or its priority pill, depending on merge state
- COVERAGE statuses flipped to reflect new shipped capabilities (A/B/C-Export/D-AI governance all now Done; only E-Process remains Partial pending #111)
- New "Follow-ups discovered during implementation" section listing #125 / #126 / #127 / #129
- Meta strip updated: `"8 filed · 6 shipped"`
- "The take" rewritten to lead with the shipped list

### Full report (`/discovery/aascu/full`)
- COVERAGE table expanded to reflect the new shipped capabilities (transparency, lineage, sensitive populations, validation report, FERPA runtime guard, FERPA audit skill, FORCE_DIRECT_DB hardening)
- Issue cards in chapters 04 now carry a `cardShipped` style (left-edge accent + ✓ instead of →) when merged
- New **chapter 05 — "Follow-ups"** with the four transparency-driven tickets
- Strip stat replaced with `Shipped 6 of 8 · plus 4 follow-ups`
- Executive summary copy updated to lead with the shipped list
- Colophon: `"Filed 2026·04·29 · Updated 2026·05·03"`

## What didn't change

- The pain-point taxonomy (chapter 02) and "what we heard" framing — those remain the authoritative record of the discovery session
- The original quotes and the "intentionally out of scope" list
- Visual language: same Newsreader/Fraunces + IBM Plex Sans + JetBrains/Plex Mono editorial direction

## Test plan

- [ ] `npm run dev` and visit `/discovery/aascu` and `/discovery/aascu/full`
- [ ] Each shipped issue card shows the **Shipped · PR #N** pill (or "Shipped" when no PR was used, e.g. #109)
- [ ] The two outstanding issues (#111, #112) show their priority pill (P2)
- [ ] Follow-ups section / chapter renders with all four tickets
- [ ] Mobile breakpoint at 640px still readable
- [ ] `npx tsc --noEmit` passes (verified)

## Related

- Part of #124 (spring-convening-followup epic)
- All 6 shipped issues + 4 follow-ups linked from the page